### PR TITLE
README: Use "ebnf" formatting for grammar sections [ci skip] [changelog skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for more details.
 
 A Cucumber Expression has the following AST:
 
-```
+```ebnf
 cucumber-expression :=  ( alternation | optional | parameter | text )*
 alternation := (?<=left-boundary) + alternative* + ( '/' + alternative* )+ + (?=right-boundary)
 left-boundary := whitespace | } | ^
@@ -19,7 +19,7 @@ text := whitespace | ')' | '}' | .
 ```
 
 The AST is constructed from the following tokens:
-```
+```ebnf
 escape := '\'
 token := whitespace | '(' | ')' | '{' | '}' | '/' | .
 . := any non-reserved codepoint
@@ -40,7 +40,7 @@ Note:
 The AST can be rewritten into a regular expression by the following production
 rules:
 
-```
+```ebnf
 cucumber-expression -> '^' + rewrite(node[0]) + ... + rewrite(node[n-1]) + '$'
 alternation -> '(?:' + rewrite(node[0]) +'|' + ...  +'|' + rewerite(node[n-1]) + ')'
 alternative -> rewrite(node[0]) + ... + rewrite(node[n-1])


### PR DESCRIPTION
# Description

In order to help the reader, this PR formats the Markdown presenting the grammar in the README.

<img width="1071" alt="bild" src="https://user-images.githubusercontent.com/211/134126329-7ba8b4fc-7737-40fb-91d7-be6f77231714.png">

# Motivation & context

It makes the text resolve itself easier for a reader.

## Type of change

- Maintenance

