### PR TITLE
fix: add name to cjs package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Add missing `name` field in CommonJS package file ([#87](https://github.com/cucumber/cucumber-expressions/pull/87))
 
 ## [15.0.1] - 2022-01-04
 ### Fixed

--- a/javascript/package.cjs.json
+++ b/javascript/package.cjs.json
@@ -1,1 +1,4 @@
-{"type": "commonjs"}
+{
+  "name": "@cucumber/cucumber-expressions",
+  "type": "commonjs"
+}


### PR DESCRIPTION
### 🤔 What's changed?

This `package.json` was confusing a tool I'm trying to use to generate API documentation in cucumber-js - just adding the name there seems to be enough.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Go over all the following points, and put an `x` in all the boxes that apply.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
