### PR TITLE
Expose the AST in the JavaScript implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- [JavaScript] Add `CucumberExpression.ast` and expose the AST types. 
+
 ## [15.0.2] - 2022-03-15
 ### Fixed
 - Add missing `name` field in CommonJS package file ([#87](https://github.com/cucumber/cucumber-expressions/pull/87))

--- a/javascript/src/Ast.ts
+++ b/javascript/src/Ast.ts
@@ -40,7 +40,7 @@ export interface Located {
   readonly end: number
 }
 
-export class Node {
+export class Node implements Located {
   constructor(
     public readonly type: NodeType,
     public readonly nodes: readonly Node[] | undefined,
@@ -70,7 +70,7 @@ export enum NodeType {
   expression = 'EXPRESSION_NODE',
 }
 
-export class Token {
+export class Token implements Located {
   readonly type: TokenType
   readonly text: string
   readonly start: number

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -1,4 +1,5 @@
 import Argument from './Argument.js'
+import { Located, Node, NodeType, Token, TokenType } from './Ast.js'
 import CucumberExpression from './CucumberExpression.js'
 import CucumberExpressionGenerator from './CucumberExpressionGenerator.js'
 import ExpressionFactory from './ExpressionFactory.js'
@@ -17,7 +18,12 @@ export {
   ExpressionFactory,
   GeneratedExpression,
   Group,
+  Located,
+  Node,
+  NodeType,
   ParameterType,
   ParameterTypeRegistry,
   RegularExpression,
+  Token,
+  TokenType,
 }


### PR DESCRIPTION
### 🤔 What's changed?

The Cucumber Expression AST is exposed via `CucumberExpression.ast`. The AST types are exported.

### ⚡️ What's your motivation? 

Having access to the AST is required to fix https://github.com/cucumber/language-service/issues/16 and possibly also https://github.com/cucumber/cucumber-expressions/issues/51

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

By doing this we're exposing the public API surface. If #41 ever gets implemented, it may require a change to the AST. We can live with that.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
