### PR TITLE
Return the expression source instead of nil

### DIFF
--- a/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
+++ b/ruby/lib/cucumber/cucumber_expressions/cucumber_expression.rb
@@ -32,7 +32,7 @@ module Cucumber
       end
 
       def to_s
-        @source.inspect
+        source.inspect
       end
 
       private

--- a/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
+++ b/ruby/spec/cucumber/cucumber_expressions/cucumber_expression_spec.rb
@@ -95,6 +95,11 @@ module Cucumber
         expect(CucumberExpression.new(expr, ParameterTypeRegistry.new).source).to eq(expr)
       end
 
+      it "exposes source via #to_s" do
+        expr = "I have {int} cuke(s)"
+        expect(CucumberExpression.new(expr, ParameterTypeRegistry.new).to_s).to eq(expr.inspect)
+      end
+
       it "unmatched optional groups have undefined values" do
         parameter_type_registry = ParameterTypeRegistry.new
         parameter_type_registry.define_parameter_type(


### PR DESCRIPTION
### 🤔 What's changed?

When running `cucumber --format=stepdefs --strict --dry-run` we saw plenty of `nil`s where the step definition should have been.

The `to_s` method referenced a non-existent instance variable `@source` instead of the `source` method.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.