### PR TITLE
Change ParameterType.regexps type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Changed
-- [JavaScript] The `ParameterType` constructor's `regexp` parameter has a new type: `type Regexps = StringOrRegExp | readonly StringOrRegExp[]; type StringOrRegExp = string | RegExp`.
+- [JavaScript] The `ParameterType` constructor's `regexps` parameter has a new type: `type Regexps = StringOrRegExp | readonly StringOrRegExp[]; type StringOrRegExp = string | RegExp`.
 
 ## [15.2.0] - 2022-05-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- [JavaScript] The `ParameterType` constructor's `regexp` parameter has a new type: `type Regexps = StringOrRegExp | readonly StringOrRegExp[]; type StringOrRegExp = string | RegExp`.
+
 ## [15.2.0] - 2022-05-24
 ### Added
 - [JavaScript] Add `ParameterInfo` ([#124](https://github.com/cucumber/cucumber-expressions/pull/124))

--- a/javascript/src/ParameterType.ts
+++ b/javascript/src/ParameterType.ts
@@ -10,6 +10,9 @@ interface Constructor<T> extends Function {
 
 type Factory<T> = (...args: unknown[]) => T
 
+type Regexps = StringOrRegExp | readonly StringOrRegExp[]
+type StringOrRegExp = string | RegExp
+
 export default class ParameterType<T> {
   private transformFn: (...match: readonly string[]) => T | PromiseLike<T>
 
@@ -40,7 +43,7 @@ export default class ParameterType<T> {
 
   /**
    * @param name {String} the name of the type
-   * @param regexps {Array.<RegExp>,RegExp,Array.<String>,String} that matches the type
+   * @param regexps {Array.<RegExp | String>,RegExp,String} that matche the type
    * @param type {Function} the prototype (constructor) of the type. May be null.
    * @param transform {Function} function transforming string to another type. May be null.
    * @param useForSnippets {boolean} true if this should be used for snippets. Defaults to true.
@@ -48,8 +51,8 @@ export default class ParameterType<T> {
    */
   constructor(
     public readonly name: string | undefined,
-    regexps: readonly RegExp[] | readonly string[] | RegExp | string,
-    public readonly type: Constructor<T> | Factory<T> | string | null,
+    regexps: Regexps,
+    public readonly type: Constructor<T> | Factory<T> | null,
     transform: (...match: string[]) => T | PromiseLike<T>,
     public readonly useForSnippets: boolean,
     public readonly preferForRegexpMatch: boolean
@@ -77,11 +80,8 @@ export default class ParameterType<T> {
   }
 }
 
-type StringOrRegexp = string | RegExp
-
-function stringArray(regexps: readonly StringOrRegexp[] | StringOrRegexp): string[] {
-  // @ts-ignore
-  const array: StringOrRegexp[] = Array.isArray(regexps) ? regexps : [regexps]
+function stringArray(regexps: Regexps): string[] {
+  const array: StringOrRegExp[] = Array.isArray(regexps) ? regexps : [regexps]
   return array.map((r) => (r instanceof RegExp ? regexpSource(r) : r))
 }
 

--- a/javascript/src/ParameterType.ts
+++ b/javascript/src/ParameterType.ts
@@ -10,8 +10,8 @@ interface Constructor<T> extends Function {
 
 type Factory<T> = (...args: unknown[]) => T
 
-type Regexps = StringOrRegExp | readonly StringOrRegExp[]
-type StringOrRegExp = string | RegExp
+export type Regexps = StringOrRegExp | readonly StringOrRegExp[]
+export type StringOrRegExp = string | RegExp
 
 export default class ParameterType<T> {
   private transformFn: (...match: readonly string[]) => T | PromiseLike<T>


### PR DESCRIPTION
### 🤔 What's changed?

The type of `regexps` in the `ParameterType` constructor has changed to `Regexps`:

```typescript
type Regexps = StringOrRegExp | readonly StringOrRegExp[]
type StringOrRegExp = string | RegExp
```

### ⚡️ What's your motivation? 

It's more convenient to use this type when the `regexps` are built at runtime (in `@cucumber/language-service`).

### 🏷️ What kind of change is this?

- :boom: Breaking change (incompatible changes to the API)

### ♻️ Anything particular you want feedback on?

Just a heads up that this is a major change since the type signature is not backwards compatible.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
