### PR TITLE
fix: ParameterType constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [JavaScript] The `ParameterType` constructor's `transform`, `useForSnippets` and `preferForRegexpMatch` should be optional. ([#178](https://github.com/cucumber/cucumber-expressions/pull/178))
 
 ## [16.0.0] - 2022-06-12
 ### Changed

--- a/javascript/src/ParameterType.ts
+++ b/javascript/src/ParameterType.ts
@@ -54,9 +54,9 @@ export default class ParameterType<T> {
     public readonly name: string | undefined,
     regexps: RegExps,
     public readonly type: Constructor<T> | Factory<T> | null,
-    transform: (...match: string[]) => T | PromiseLike<T>,
-    public readonly useForSnippets: boolean,
-    public readonly preferForRegexpMatch: boolean
+    transform?: (...match: string[]) => T | PromiseLike<T>,
+    public readonly useForSnippets?: boolean,
+    public readonly preferForRegexpMatch?: boolean
   ) {
     if (transform === undefined) {
       transform = (s) => s as unknown as T


### PR DESCRIPTION
### 🤔 What's changed?

`transform`, `useForSnippets` and `preferForRegexpMatch` can all be optional.

### ⚡️ What's your motivation? 

I'm using this library separately and found this type issue.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

If `type` can be `null`, can it be `undefined` and optional too?

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
