### PR TITLE
Improve CucumberExpression creation performance

### DIFF
--- a/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpression.java
+++ b/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpression.java
@@ -24,7 +24,7 @@ import static java.util.stream.Collectors.joining;
 
 @API(status = API.Status.STABLE)
 public final class CucumberExpression implements Expression {
-    private static final Pattern ESCAPE_PATTERN = Pattern.compile("([\\\\^\\[({$.|?*+})\\]])");
+    private static final Pattern ESCAPE_PATTERN = Pattern.compile("[\\\\^\\[({$.|?*+})\\]]");
 
     private final List<ParameterType<?>> parameterTypes = new ArrayList<>();
     private final String source;
@@ -62,7 +62,7 @@ public final class CucumberExpression implements Expression {
     }
 
     private static String escapeRegex(String text) {
-        return ESCAPE_PATTERN.matcher(text).replaceAll("\\\\$1");
+        return ESCAPE_PATTERN.matcher(text).replaceAll("\\\\$0");
     }
 
     private String rewriteOptional(Node node) {


### PR DESCRIPTION
### 🤔 What's changed?

I rewrote a regular expression to improve `CucumberExpression` creation performance.

### ⚡️ What's your motivation? 

My motivation is to have a better performance for the Cucumber framework.

I made a benchmark with JMH which shows that the modified method is about 15% faster (see escapeRegex2 below) :

Benchmark                                  Mode  Cnt       Score       Error  Units
CucumberExpressionBenchmark.escapeRegex0  thrpt   25  726563,091 ± 15558,020  ops/s
CucumberExpressionBenchmark.escapeRegex2  thrpt   25  833512,235 ± 25088,968  ops/s

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Nothing.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code

