### PR TITLE
Feature/enable transformer capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [JavaScript] Added TypeScript source to the package ([#211](https://github.com/cucumber/cucumber-expressions/pull/211))
 - [Ruby] Minimum supported ruby is now 2.5+ ([#232](https://github.com/cucumber/cucumber-expressions/pull/232))
 - [Ruby] Large suite wide refactor for basic rubocop compliance ([#233](https://github.com/cucumber/cucumber-expressions/pull/233))
+- [Ruby] Change public API readers for `ParameterType`
+  - Expose `transformer` arg as a public reader
+  - Remove `prefer_for_regexp_match?` and `use_for_snippets?` -> Use their reader equivalents instead (Remove the `?`)
+    ([#234](https://github.com/cucumber/cucumber-expressions/pull/234))
 
 ## [16.1.2] - 2023-01-17
 ### Fixed

--- a/ruby/lib/cucumber/cucumber_expressions/cucumber_expression_generator.rb
+++ b/ruby/lib/cucumber/cucumber_expressions/cucumber_expression_generator.rb
@@ -69,7 +69,7 @@ module Cucumber
       def create_parameter_type_matchers(text)
         parameter_matchers = []
         @parameter_type_registry.parameter_types.each do |parameter_type|
-          parameter_matchers += create_parameter_type_matchers2(parameter_type, text) if parameter_type.use_for_snippets?
+          parameter_matchers += create_parameter_type_matchers2(parameter_type, text) if parameter_type.use_for_snippets
         end
         parameter_matchers
       end

--- a/ruby/lib/cucumber/cucumber_expressions/parameter_type.rb
+++ b/ruby/lib/cucumber/cucumber_expressions/parameter_type.rb
@@ -47,8 +47,8 @@ module Cucumber
       end
 
       def <=>(other)
-        return -1 if prefer_for_regexp_match? && !other.prefer_for_regexp_match?
-        return 1 if other.prefer_for_regexp_match? && !prefer_for_regexp_match?
+        return -1 if prefer_for_regexp_match && !other.prefer_for_regexp_match
+        return 1 if other.prefer_for_regexp_match && !prefer_for_regexp_match
         return name <=> other.name
       end
 

--- a/ruby/lib/cucumber/cucumber_expressions/parameter_type.rb
+++ b/ruby/lib/cucumber/cucumber_expressions/parameter_type.rb
@@ -8,7 +8,7 @@ module Cucumber
       ILLEGAL_PARAMETER_NAME_PATTERN = /([\[\]()$.|?*+])/.freeze
       UNESCAPE_PATTERN = /(\\([\[$.|?*+\]]))/.freeze
 
-      attr_reader :name, :type, :regexps
+      attr_reader :name, :type, :transformer, :use_for_snippets, :prefer_for_regexp_match, :regexps
 
       def self.check_parameter_type_name(type_name)
         raise CucumberExpressionError.new("Illegal character in parameter name {#{type_name}}. Parameter names may not contain '[]()$.|?*+'") unless is_valid_parameter_type_name(type_name)
@@ -19,14 +19,6 @@ module Cucumber
           $2
         end
         !(ILLEGAL_PARAMETER_NAME_PATTERN =~ unescaped_type_name)
-      end
-
-      def prefer_for_regexp_match?
-        @prefer_for_regexp_match
-      end
-
-      def use_for_snippets?
-        @use_for_snippets
       end
 
       # Create a new Parameter
@@ -62,7 +54,6 @@ module Cucumber
 
       private
 
-
       def string_array(regexps)
         array = regexps.is_a?(Array) ? regexps : [regexps]
         array.map { |regexp| regexp.is_a?(String) ? regexp : regexp_source(regexp) }
@@ -70,9 +61,9 @@ module Cucumber
 
       def regexp_source(regexp)
         [
-            'EXTENDED',
-            'IGNORECASE',
-            'MULTILINE'
+          'EXTENDED',
+          'IGNORECASE',
+          'MULTILINE'
         ].each do |option_name|
           option = Regexp.const_get(option_name)
           raise CucumberExpressionError.new("ParameterType Regexps can't use option Regexp::#{option_name}") if regexp.options & option != 0

--- a/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
+++ b/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
@@ -38,7 +38,7 @@ module Cucumber
       def lookup_by_regexp(parameter_type_regexp, expression_regexp, text)
         parameter_types = @parameter_types_by_regexp[parameter_type_regexp]
         return nil if parameter_types.nil?
-        if parameter_types.length > 1 && !parameter_types[0].prefer_for_regexp_match?
+        if parameter_types.length > 1 && !parameter_types[0].prefer_for_regexp_match
           # We don't do this check on insertion because we only want to restrict
           # ambiguity when we look up by Regexp. Users of CucumberExpression should
           # not be restricted.
@@ -66,7 +66,7 @@ module Cucumber
 
         parameter_type.regexps.each do |parameter_type_regexp|
           parameter_types = @parameter_types_by_regexp[parameter_type_regexp]
-          if parameter_types.any? && parameter_types[0].prefer_for_regexp_match? && parameter_type.prefer_for_regexp_match?
+          if parameter_types.any? && parameter_types[0].prefer_for_regexp_match && parameter_type.prefer_for_regexp_match
             raise CucumberExpressionError.new("There can only be one preferential parameter type per regexp. The regexp /#{parameter_type_regexp}/ is used for two preferential parameter types, {#{parameter_types[0].name}} and {#{parameter_type.name}}")
           end
           parameter_types.push(parameter_type)


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Expose `transformer` arg on `ParameterType`.

### ⚡️ What's your motivation? 

 Needed for CCK conformancy (v12/v13) for cucumber-ruby. We need to store the `SourceLocation` proc for the `ParameterType`, this is currently not possible.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)
- :boom: Breaking change (incompatible changes to the API)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
