### PR TITLE
Update to poetry v1.6.1 in release-python.yml

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with: 
-          version: 1.1.13
+          version: 1.6.1
           
       - name: Install dependencies
         run: poetry install


### PR DESCRIPTION
### 🤔 What's changed?

The version of poetry is changed from 1.1.13 to 1.6.1

### ⚡️ What's your motivation? 

To try and fix the release error: https://github.com/cucumber/cucumber-expressions/actions/runs/6432369369/job/17467078344

The root cause is that requests_toolbelt < v1.0 and urllib3 >= 2.0 is used together. These packages are not dependencies of cucumber-expressions, so it must be poetry which uses them and define their versions.

These comments indicate that an updated to a later version of poetry should fix the problem:
https://github.com/psf/requests/issues/6441#issuecomment-1633151880


### 🏷️ What kind of change is this?


x :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
