### PR TITLE
Fix import paths lacking file suffix

### DIFF
--- a/javascript/src/ParameterTypeRegistry.ts
+++ b/javascript/src/ParameterTypeRegistry.ts
@@ -3,7 +3,7 @@ import CucumberExpressionGenerator from './CucumberExpressionGenerator.js'
 import defineDefaultParameterTypes from './defineDefaultParameterTypes.js'
 import { AmbiguousParameterTypeError } from './Errors.js'
 import ParameterType from './ParameterType.js'
-import { DefinesParameterType } from './types'
+import { DefinesParameterType } from './types.js'
 
 export default class ParameterTypeRegistry implements DefinesParameterType {
   private readonly parameterTypeByName = new Map<string, ParameterType<unknown>>()

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -1,5 +1,5 @@
 import Argument from './Argument.js'
-import ParameterType from './ParameterType'
+import ParameterType from './ParameterType.js'
 
 export interface DefinesParameterType {
   defineParameterType<T>(parameterType: ParameterType<T>): void


### PR DESCRIPTION
Two import paths were lacking a js suffix and were generating TS errors
in projects depending on this one.
