### PR TITLE
Fix typo for alternation in optional error message

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,14 +28,11 @@ token  = whitespace | "(" | ")" | "{" | "}" | "/" | .
 ```
 
 Note:
- * While `parameter` is allowed to appear as part of `alternative` and
-  `option` in the AST, such an AST is not a valid a Cucumber Expression.
- * While `optional` is allowed to appear as part of `option` in the AST,
-   such an AST is not a valid a Cucumber Expression.
- * ASTs with empty alternatives or alternatives that only
-   contain an optional are valid ASTs but invalid Cucumber Expressions.
- * All escaped tokens (tokens starting with a backslash) are rewritten to their
-   unescaped equivalent after parsing.
+
+* While `parameter` is allowed to appear as part of `alternative` and `option` in the AST, such an AST is not a valid Cucumber Expression.
+* While `optional` is allowed to appear as part of `option` in the AST, such an AST is not a valid Cucumber Expression.
+* ASTs with empty alternatives or alternatives that only contain an optional are valid ASTs but invalid Cucumber Expressions.
+* All escaped tokens (tokens starting with a backslash) are rewritten to their unescaped equivalent after parsing.
 
 ### Production Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [Ruby] Added subsidiary rubocop gems (RSpec/Rake/Performance), and did some initial refactoring ([#247](https://github.com/cucumber/cucumber-expressions/pull/247))
 
+### Fixed
+- Removed repeated 'the' from error message for use of alternations inside optionals ([#252](https://github.com/cucumber/cucumber-expressions/issues/252))
+
 ## [17.0.1] - 2023-11-24
 ### Fixed
 - [JavaScript] Fix import paths lacking file suffix ([#243](https://github.com/cucumber/cucumber-expressions/pull/243))

--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ public Color ConvertColor(string colorValue)
 
 ```python
 ParameterType(
-  name=        'color',
+  name=        "color",
   regexp=      "red|blue|yellow",
-  type=  Color,
+  type=        Color,
   transformer= lambda s: Color(),
 )
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,1 +1,3 @@
+# Releasing
+
 See [.github/RELEASING](https://github.com/cucumber/.github/blob/main/RELEASING.md).

--- a/dotnet/CucumberExpressions/CucumberExpressionException.cs
+++ b/dotnet/CucumberExpressions/CucumberExpressionException.cs
@@ -30,7 +30,7 @@ public class CucumberExpressionException : Exception {
                 expression,
                 PointAt(current),
                 "An alternation can not be used inside an optional",
-                "You can use '\\/' to escape the the '/'"
+                "You can use '\\/' to escape the '/'"
         ));
     }
 
@@ -41,7 +41,7 @@ public class CucumberExpressionException : Exception {
                 expression,
                 PointAt(index),
                 "The end of line can not be escaped",
-                "You can use '\\\\' to escape the the '\\'"
+                "You can use '\\\\' to escape the '\\'"
         ));
     }
 
@@ -51,7 +51,7 @@ public class CucumberExpressionException : Exception {
                 expression,
                 PointAt(node),
                 "Alternative may not be empty",
-                "If you did not mean to use an alternative you can use '\\/' to escape the the '/'"));
+                "If you did not mean to use an alternative you can use '\\/' to escape the '/'"));
     }
 
     internal static CucumberExpressionException CreateParameterIsNotAllowedInOptional(Node node, string expression) {
@@ -60,7 +60,7 @@ public class CucumberExpressionException : Exception {
                 expression,
                 PointAt(node),
                 "An optional may not contain a parameter type",
-                "If you did not mean to use an parameter type you can use '\\{' to escape the the '{'"));
+                "If you did not mean to use an parameter type you can use '\\{' to escape the '{'"));
     }
     internal static CucumberExpressionException CreateOptionalIsNotAllowedInOptional(Node node, string expression) {
         return new CucumberExpressionException(GetMessage(
@@ -68,7 +68,7 @@ public class CucumberExpressionException : Exception {
                 expression,
                 PointAt(node),
                 "An optional may not contain an other optional",
-                "If you did not mean to use an optional type you can use '\\(' to escape the the '('. For more complicated expressions consider using a regular expression instead."));
+                "If you did not mean to use an optional type you can use '\\(' to escape the '('. For more complicated expressions consider using a regular expression instead."));
     }
 
     internal static CucumberExpressionException CreateOptionalMayNotBeEmpty(Node node, string expression) {
@@ -77,7 +77,7 @@ public class CucumberExpressionException : Exception {
                 expression,
                 PointAt(node),
                 "An optional must contain some text",
-                "If you did not mean to use an optional you can use '\\(' to escape the the '('"));
+                "If you did not mean to use an optional you can use '\\(' to escape the '('"));
     }
 
     internal static CucumberExpressionException CreateAlternativeMayNotExclusivelyContainOptionals(Node node,
@@ -87,7 +87,7 @@ public class CucumberExpressionException : Exception {
                 expression,
                 PointAt(node),
                 "An alternative may not exclusively contain optionals",
-                "If you did not mean to use an optional you can use '\\(' to escape the the '('"));
+                "If you did not mean to use an optional you can use '\\(' to escape the '('"));
     }
 
     private static string ThisCucumberExpressionHasAProblemAt(int index) {

--- a/go/errors.go
+++ b/go/errors.go
@@ -34,7 +34,7 @@ func createAlternationNotAllowedInOptional(expression string, current token) err
 		expression,
 		pointAtToken(current),
 		"An alternation can not be used inside an optional",
-		"You can use '\\/' to escape the the '/'",
+		"You can use '\\/' to escape the '/'",
 	))
 }
 
@@ -45,7 +45,7 @@ func createTheEndOfLineCanNotBeEscaped(expression string) error {
 		expression,
 		pointAt(index),
 		"The end of line can not be escaped",
-		"You can use '\\\\' to escape the the '\\'",
+		"You can use '\\\\' to escape the '\\'",
 	))
 }
 
@@ -55,7 +55,7 @@ func createOptionalMayNotBeEmpty(node node, expression string) error {
 		expression,
 		pointAtNode(node),
 		"An optional must contain some text",
-		"If you did not mean to use an optional you can use '\\(' to escape the the '('",
+		"If you did not mean to use an optional you can use '\\(' to escape the '('",
 	))
 }
 func createParameterIsNotAllowedInOptional(node node, expression string) error {
@@ -64,7 +64,7 @@ func createParameterIsNotAllowedInOptional(node node, expression string) error {
 		expression,
 		pointAtNode(node),
 		"An optional may not contain a parameter type",
-		"If you did not mean to use an parameter type you can use '\\{' to escape the the '{'",
+		"If you did not mean to use an parameter type you can use '\\{' to escape the '{'",
 	))
 }
 func createOptionalIsNotAllowedInOptional(node node, expression string) error {
@@ -73,7 +73,7 @@ func createOptionalIsNotAllowedInOptional(node node, expression string) error {
 		expression,
 		pointAtNode(node),
 		"An optional may not contain an other optional",
-		"If you did not mean to use an optional type you can use '\\(' to escape the the '('. For more complicated expressions consider using a regular expression instead.",
+		"If you did not mean to use an optional type you can use '\\(' to escape the '('. For more complicated expressions consider using a regular expression instead.",
 	))
 }
 func createAlternativeMayNotBeEmpty(node node, expression string) error {
@@ -82,7 +82,7 @@ func createAlternativeMayNotBeEmpty(node node, expression string) error {
 		expression,
 		pointAtNode(node),
 		"Alternative may not be empty",
-		"If you did not mean to use an alternative you can use '\\/' to escape the the '/'",
+		"If you did not mean to use an alternative you can use '\\/' to escape the '/'",
 	))
 }
 func createAlternativeMayNotExclusivelyContainOptionals(node node, expression string) error {
@@ -91,7 +91,7 @@ func createAlternativeMayNotExclusivelyContainOptionals(node node, expression st
 		expression,
 		pointAtNode(node),
 		"An alternative may not exclusively contain optionals",
-		"If you did not mean to use an optional you can use '\\(' to escape the the '('",
+		"If you did not mean to use an optional you can use '\\(' to escape the '('",
 	))
 }
 

--- a/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionException.java
+++ b/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionException.java
@@ -34,7 +34,7 @@ public class CucumberExpressionException extends RuntimeException {
                 expression,
                 pointAt(current),
                 "An alternation can not be used inside an optional",
-                "You can use '\\/' to escape the the '/'"
+                "You can use '\\/' to escape the '/'"
         ));
     }
 
@@ -45,7 +45,7 @@ public class CucumberExpressionException extends RuntimeException {
                 expression,
                 pointAt(index),
                 "The end of line can not be escaped",
-                "You can use '\\\\' to escape the the '\\'"
+                "You can use '\\\\' to escape the '\\'"
         ));
     }
 
@@ -55,7 +55,7 @@ public class CucumberExpressionException extends RuntimeException {
                 expression,
                 pointAt(node),
                 "Alternative may not be empty",
-                "If you did not mean to use an alternative you can use '\\/' to escape the the '/'"));
+                "If you did not mean to use an alternative you can use '\\/' to escape the '/'"));
     }
 
     static CucumberExpressionException createParameterIsNotAllowedInOptional(Node node, String expression) {
@@ -64,7 +64,7 @@ public class CucumberExpressionException extends RuntimeException {
                 expression,
                 pointAt(node),
                 "An optional may not contain a parameter type",
-                "If you did not mean to use an parameter type you can use '\\{' to escape the the '{'"));
+                "If you did not mean to use an parameter type you can use '\\{' to escape the '{'"));
     }
     static CucumberExpressionException createOptionalIsNotAllowedInOptional(Node node, String expression) {
         return new CucumberExpressionException(message(
@@ -72,7 +72,7 @@ public class CucumberExpressionException extends RuntimeException {
                 expression,
                 pointAt(node),
                 "An optional may not contain an other optional",
-                "If you did not mean to use an optional type you can use '\\(' to escape the the '('. For more complicated expressions consider using a regular expression instead."));
+                "If you did not mean to use an optional type you can use '\\(' to escape the '('. For more complicated expressions consider using a regular expression instead."));
     }
 
     static CucumberExpressionException createOptionalMayNotBeEmpty(Node node, String expression) {
@@ -81,7 +81,7 @@ public class CucumberExpressionException extends RuntimeException {
                 expression,
                 pointAt(node),
                 "An optional must contain some text",
-                "If you did not mean to use an optional you can use '\\(' to escape the the '('"));
+                "If you did not mean to use an optional you can use '\\(' to escape the '('"));
     }
 
     static CucumberExpressionException createAlternativeMayNotExclusivelyContainOptionals(Node node,
@@ -91,7 +91,7 @@ public class CucumberExpressionException extends RuntimeException {
                 expression,
                 pointAt(node),
                 "An alternative may not exclusively contain optionals",
-                "If you did not mean to use an optional you can use '\\(' to escape the the '('"));
+                "If you did not mean to use an optional you can use '\\(' to escape the '('"));
     }
 
     private static String thisCucumberExpressionHasAProblemAt(int index) {

--- a/java/src/main/java/io/cucumber/cucumberexpressions/RegularExpression.java
+++ b/java/src/main/java/io/cucumber/cucumberexpressions/RegularExpression.java
@@ -47,7 +47,7 @@ public final class RegularExpression implements Expression {
             ParameterType<?> parameterType = parameterTypeRegistry.lookupByRegexp(parameterTypeRegexp, expressionRegexp, text);
 
             // When there is a conflict between the type hint from the regular expression and the method
-            // prefer the the parameter type associated with the regular expression. This ensures we will
+            // prefer the parameter type associated with the regular expression. This ensures we will
             // use the internal/user registered parameter transformer rather then the default.
             //
             // Unless the parameter type indicates it is the stronger type hint.

--- a/javascript/src/Errors.ts
+++ b/javascript/src/Errors.ts
@@ -13,7 +13,7 @@ export function createAlternativeMayNotExclusivelyContainOptionals(
       expression,
       pointAtLocated(node),
       'An alternative may not exclusively contain optionals',
-      "If you did not mean to use an optional you can use '\\(' to escape the the '('"
+      "If you did not mean to use an optional you can use '\\(' to escape the '('"
     )
   )
 }
@@ -27,7 +27,7 @@ export function createAlternativeMayNotBeEmpty(
       expression,
       pointAtLocated(node),
       'Alternative may not be empty',
-      "If you did not mean to use an alternative you can use '\\/' to escape the the '/'"
+      "If you did not mean to use an alternative you can use '\\/' to escape the '/'"
     )
   )
 }
@@ -41,7 +41,7 @@ export function createOptionalMayNotBeEmpty(
       expression,
       pointAtLocated(node),
       'An optional must contain some text',
-      "If you did not mean to use an optional you can use '\\(' to escape the the '('"
+      "If you did not mean to use an optional you can use '\\(' to escape the '('"
     )
   )
 }
@@ -55,7 +55,7 @@ export function createParameterIsNotAllowedInOptional(
       expression,
       pointAtLocated(node),
       'An optional may not contain a parameter type',
-      "If you did not mean to use an parameter type you can use '\\{' to escape the the '{'"
+      "If you did not mean to use an parameter type you can use '\\{' to escape the '{'"
     )
   )
 }
@@ -70,7 +70,7 @@ export function createOptionalIsNotAllowedInOptional(
       expression,
       pointAtLocated(node),
       'An optional may not contain an other optional',
-      "If you did not mean to use an optional type you can use '\\(' to escape the the '('. For more complicated expressions consider using a regular expression instead."
+      "If you did not mean to use an optional type you can use '\\(' to escape the '('. For more complicated expressions consider using a regular expression instead."
     )
   )
 }
@@ -83,7 +83,7 @@ export function createTheEndOfLIneCanNotBeEscaped(expression: string): CucumberE
       expression,
       pointAt(index),
       'The end of line can not be escaped',
-      "You can use '\\\\' to escape the the '\\'"
+      "You can use '\\\\' to escape the '\\'"
     )
   )
 }
@@ -115,7 +115,7 @@ export function createAlternationNotAllowedInOptional(expression: string, curren
       expression,
       pointAtLocated(current),
       'An alternation can not be used inside an optional',
-      "You can use '\\/' to escape the the '/'"
+      "You can use '\\/' to escape the '/'"
     )
   )
 }

--- a/python/cucumber_expressions/errors.py
+++ b/python/cucumber_expressions/errors.py
@@ -42,7 +42,7 @@ class AlternativeMayNotExclusivelyContainOptionals(CucumberExpressionError):
                 expression=expression,
                 pointer=point_at_located(node),
                 problem="An alternative may not exclusively contain optionals",
-                solution="If you did not mean to use an optional you can use '\\(' to escape the the '('",
+                solution="If you did not mean to use an optional you can use '\\(' to escape the '('",
             )
         )
 
@@ -55,7 +55,7 @@ class AlternativeMayNotBeEmpty(CucumberExpressionError):
                 expression=expression,
                 pointer=point_at_located(node),
                 problem="Alternative may not be empty",
-                solution="If you did not mean to use an alternative you can use '\\/' to escape the the '/'",
+                solution="If you did not mean to use an alternative you can use '\\/' to escape the '/'",
             )
         )
 
@@ -81,7 +81,7 @@ class OptionalMayNotBeEmpty(CucumberExpressionError):
                 expression=expression,
                 pointer=point_at_located(node),
                 problem="An optional must contain some text",
-                solution="If you did not mean to use an optional you can use '\\(' to escape the the '('",
+                solution="If you did not mean to use an optional you can use '\\(' to escape the '('",
             )
         )
 
@@ -94,7 +94,7 @@ class ParameterIsNotAllowedInOptional(CucumberExpressionError):
                 expression=expression,
                 pointer=point_at_located(node),
                 problem="An optional may not contain a parameter type",
-                solution="If you did not mean to use an parameter type you can use '\\{' to escape the the '{'",
+                solution="If you did not mean to use an parameter type you can use '\\{' to escape the '{'",
             )
         )
 
@@ -108,7 +108,7 @@ class OptionalIsNotAllowedInOptional(CucumberExpressionError):
                 pointer=point_at_located(node),
                 problem="An optional may not contain an other optional",
                 solution=(
-                    "If you did not mean to use an optional type you can use '\\(' to escape the the '('. "
+                    "If you did not mean to use an optional type you can use '\\(' to escape the '('. "
                     "For more complicated expressions consider using a regular expression instead."
                 ),
             )
@@ -140,7 +140,7 @@ class AlternationNotAllowedInOptional(CucumberExpressionError):
                 expression=expression,
                 pointer=point_at_located(current),
                 problem="An alternation can not be used inside an optional",
-                solution="You can use '\\/' to escape the the '/'",
+                solution="You can use '\\/' to escape the '/'",
             )
         )
 
@@ -220,6 +220,6 @@ class TheEndOfLineCannotBeEscaped(CucumberExpressionError):
                 expression=expression,
                 pointer=point_at(index),
                 problem="The end of line can not be escaped",
-                solution="You can use '\\\\' to escape the the '\\'",
+                solution="You can use '\\\\' to escape the '\\'",
             )
         )

--- a/ruby/lib/cucumber/cucumber_expressions/errors.rb
+++ b/ruby/lib/cucumber/cucumber_expressions/errors.rb
@@ -41,7 +41,7 @@ module Cucumber
             expression,
             point_at_located(node),
             'An alternative may not exclusively contain optionals',
-            "If you did not mean to use an optional you can use '\\(' to escape the the '('"
+            "If you did not mean to use an optional you can use '\\(' to escape the '('"
           )
         )
       end
@@ -55,7 +55,7 @@ module Cucumber
             expression,
             point_at_located(node),
             'Alternative may not be empty',
-            "If you did not mean to use an alternative you can use '\\/' to escape the the '/'"
+            "If you did not mean to use an alternative you can use '\\/' to escape the '/'"
           )
         )
       end
@@ -83,7 +83,7 @@ module Cucumber
             expression,
             point_at_located(node),
             'An optional must contain some text',
-            "If you did not mean to use an optional you can use '\\(' to escape the the '('"
+            "If you did not mean to use an optional you can use '\\(' to escape the '('"
           )
         )
       end
@@ -97,7 +97,7 @@ module Cucumber
             expression,
             point_at_located(node),
             'An optional may not contain a parameter type',
-            "If you did not mean to use an parameter type you can use '\\{' to escape the the '{'"
+            "If you did not mean to use an parameter type you can use '\\{' to escape the '{'"
           )
         )
       end
@@ -111,7 +111,7 @@ module Cucumber
             expression,
             point_at_located(node),
             'An optional may not contain an other optional',
-            "If you did not mean to use an optional type you can use '\\(' to escape the the '('. For more complicated expressions consider using a regular expression instead."
+            "If you did not mean to use an optional type you can use '\\(' to escape the '('. For more complicated expressions consider using a regular expression instead."
           )
         )
       end
@@ -126,7 +126,7 @@ module Cucumber
             expression,
             point_at(index),
             'The end of line can not be escaped',
-            "You can use '\\\\' to escape the the '\\'"
+            "You can use '\\\\' to escape the '\\'"
           )
         )
       end
@@ -158,7 +158,7 @@ module Cucumber
             expression,
             point_at_located(current),
             'An alternation can not be used inside an optional',
-            "You can use '\\/' to escape the the '/'"
+            "You can use '\\/' to escape the '/'"
           )
         )
       end

--- a/testdata/cucumber-expression/matching/does-not-allow-alternation-in-optional.yaml
+++ b/testdata/cucumber-expression/matching/does-not-allow-alternation-in-optional.yaml
@@ -7,4 +7,4 @@ exception: |-
   three( brown/black) mice
               ^
   An alternation can not be used inside an optional.
-  You can use '\/' to escape the the '/'
+  You can use '\/' to escape the '/'

--- a/testdata/cucumber-expression/matching/does-not-allow-alternation-with-empty-alternative-by-adjacent-left-parameter.yaml
+++ b/testdata/cucumber-expression/matching/does-not-allow-alternation-with-empty-alternative-by-adjacent-left-parameter.yaml
@@ -7,4 +7,4 @@ exception: |-
   {int}/x
        ^
   Alternative may not be empty.
-  If you did not mean to use an alternative you can use '\/' to escape the the '/'
+  If you did not mean to use an alternative you can use '\/' to escape the '/'

--- a/testdata/cucumber-expression/matching/does-not-allow-alternation-with-empty-alternative-by-adjacent-optional.yaml
+++ b/testdata/cucumber-expression/matching/does-not-allow-alternation-with-empty-alternative-by-adjacent-optional.yaml
@@ -7,4 +7,4 @@ exception: |-
   three (brown)/black mice
         ^-----^
   An alternative may not exclusively contain optionals.
-  If you did not mean to use an optional you can use '\(' to escape the the '('
+  If you did not mean to use an optional you can use '\(' to escape the '('

--- a/testdata/cucumber-expression/matching/does-not-allow-alternation-with-empty-alternative-by-adjacent-right-parameter.yaml
+++ b/testdata/cucumber-expression/matching/does-not-allow-alternation-with-empty-alternative-by-adjacent-right-parameter.yaml
@@ -7,4 +7,4 @@ exception: |-
   x/{int}
     ^
   Alternative may not be empty.
-  If you did not mean to use an alternative you can use '\/' to escape the the '/'
+  If you did not mean to use an alternative you can use '\/' to escape the '/'

--- a/testdata/cucumber-expression/matching/does-not-allow-alternation-with-empty-alternative.yaml
+++ b/testdata/cucumber-expression/matching/does-not-allow-alternation-with-empty-alternative.yaml
@@ -7,4 +7,4 @@ exception: |-
   three brown//black mice
               ^
   Alternative may not be empty.
-  If you did not mean to use an alternative you can use '\/' to escape the the '/'
+  If you did not mean to use an alternative you can use '\/' to escape the '/'

--- a/testdata/cucumber-expression/matching/does-not-allow-empty-optional.yaml
+++ b/testdata/cucumber-expression/matching/does-not-allow-empty-optional.yaml
@@ -7,4 +7,4 @@ exception: |-
   three () mice
         ^^
   An optional must contain some text.
-  If you did not mean to use an optional you can use '\(' to escape the the '('
+  If you did not mean to use an optional you can use '\(' to escape the '('

--- a/testdata/cucumber-expression/matching/does-not-allow-nested-optional.yaml
+++ b/testdata/cucumber-expression/matching/does-not-allow-nested-optional.yaml
@@ -6,4 +6,4 @@ exception: |-
   (a(b))
     ^-^
   An optional may not contain an other optional.
-  If you did not mean to use an optional type you can use '\(' to escape the the '('. For more complicated expressions consider using a regular expression instead.
+  If you did not mean to use an optional type you can use '\(' to escape the '('. For more complicated expressions consider using a regular expression instead.

--- a/testdata/cucumber-expression/matching/does-not-allow-optional-parameter-types.yaml
+++ b/testdata/cucumber-expression/matching/does-not-allow-optional-parameter-types.yaml
@@ -7,4 +7,4 @@ exception: |-
   ({int})
    ^---^
   An optional may not contain a parameter type.
-  If you did not mean to use an parameter type you can use '\{' to escape the the '{'
+  If you did not mean to use an parameter type you can use '\{' to escape the '{'

--- a/testdata/cucumber-expression/tokenizer/escaped-end-of-line.yaml
+++ b/testdata/cucumber-expression/tokenizer/escaped-end-of-line.yaml
@@ -6,4 +6,4 @@ exception: |-
   \
   ^
   The end of line can not be escaped.
-  You can use '\\' to escape the the '\'
+  You can use '\\' to escape the '\'


### PR DESCRIPTION
Fixes repeated 'the' in the error message for an alternation inside an optional.

### 🤔 What's changed?

- Removed all 'the' repeats in error messages for alternations inside optionals.
- Fixed typo in `Architecture.md` - `is not a valid a Cucumber Expression` -> `is not a valid Cucumber Expression`
- Fixed alignment and formatting of Python parameter example in `README.md`

### ⚡️ What's your motivation? 

Fixes #252

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

NA.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)