### PR TITLE
Fix missing Python parameter type defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Removed repeated 'the' from error message for use of alternations inside optionals ([#252](https://github.com/cucumber/cucumber-expressions/issues/252))
+- [Python] Missing keyword argument defaults in parameter type class ([#259](https://github.com/cucumber/cucumber-expressions/pull/259))
 
 ## [17.0.1] - 2023-11-24
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -224,8 +224,7 @@ Then this expression would match the following example:
     I have 1 \{what} cucumber in my belly \(amazing!)
     I have 42 \{what} cucumbers in my belly \(amazing!)
 
-There is currently no way to escape a `/` character - it will always be interpreted
-as alternative text.
+The `/` character will always be interpreted as an alternative, unless escaped, such as with `\/`.
 
 ## Architecture
 

--- a/python/cucumber_expressions/parameter_type.py
+++ b/python/cucumber_expressions/parameter_type.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import List, Pattern, Union
+from typing import Pattern
 
 from cucumber_expressions.errors import CucumberExpressionError
 
@@ -48,8 +48,8 @@ class ParameterType:
         regexp,
         type,
         transformer,
-        use_for_snippets,
-        prefer_for_regexp_match,
+        use_for_snippets: bool = True,
+        prefer_for_regexp_match: bool = False,
     ):
         """Creates a new Parameter
         :param name: name of the parameter type
@@ -96,11 +96,9 @@ class ParameterType:
                 )
         return regexp_pattern.pattern
 
-    def to_array(
-        self, regexps: Union[List[str], str, List[Pattern], Pattern]
-    ) -> List[str]:
+    def to_array(self, regexps: list[str] | str | list[Pattern] | Pattern) -> list[str]:
         """Make a list of regexps if not already"""
-        array: List = regexps if isinstance(regexps, list) else [regexps]
+        array: list = regexps if isinstance(regexps, list) else [regexps]
         return [
             regexp if isinstance(regexp, str) else self._get_regexp_source(regexp)
             for regexp in array

--- a/python/tests/test_custom_parameter_type.py
+++ b/python/tests/test_custom_parameter_type.py
@@ -62,6 +62,24 @@ class TestCustomParameterType:
         transformed_argument_value = expression.match("I have a red ball")[0]
         assert transformed_argument_value.value == Color("red")
 
+    def test_matches_parameters_without_snippet_and_regex_parameters(
+        self,
+    ):
+        parameter_type_registry = ParameterTypeRegistry()
+        parameter_type_registry.define_parameter_type(
+            ParameterType(
+                "color",
+                r"red|blue|yellow",
+                Color,
+                lambda s: Color(s),
+            )
+        )
+        expression = CucumberExpression(
+            "I have a {color} ball", parameter_type_registry
+        )
+        argument_value = expression.match("I have a red ball")[0].value
+        assert argument_value == Color("red")
+
     def test_matches_parameters_with_multiple_capture_groups(self):
         self._parameter_type_registry.define_parameter_type(
             ParameterType(


### PR DESCRIPTION
### 🤔 What's changed?

The project documentation outlines for [Customer Parameter Types](prefer_for_regexp_match) that `use_for_snippets` "Defaults to `true`"  and that `prefer_for_regexp_match` "Defaults to `false`".

Although this aligns with the documented [Python example](prefer_for_regexp_match), its implementation is missing default values for those keyword arguments:

```python
class ParameterType:
    def __init__(
        self,
        name,
        regexp,
        type,
        transformer,
        use_for_snippets,
        prefer_for_regexp_match,
    ):
```

With this PR:

1. The appropriate defaults have been added to the `ParameterType` class. 
2. Two versions of Python type hints in the module defining that class have been reduced to one e.g. `typing.List` and `list` (through`__future__.annotations`).

### ⚡️ What's your motivation? 

- Fix a bug where default keyword arguments were not set for customer parameter types in Python
- Remove invalid documentation that alternatives can not be escaped

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Whether small correction to alternatives in README.md is appropriate.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.