### PR TITLE
Verbose alternation-in-optional error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - [Ruby] Added subsidiary rubocop gems (RSpec/Rake/Performance), and did some initial refactoring ([#247](https://github.com/cucumber/cucumber-expressions/pull/247))
+- Additional information for alternation inside optional error message on how to fix ([#260](https://github.com/cucumber/cucumber-expressions/pull/260))
 
 ### Fixed
 - Removed repeated 'the' from error message for use of alternations inside optionals ([#252](https://github.com/cucumber/cucumber-expressions/issues/252))

--- a/dotnet/CucumberExpressions/CucumberExpressionException.cs
+++ b/dotnet/CucumberExpressions/CucumberExpressionException.cs
@@ -30,7 +30,7 @@ public class CucumberExpressionException : Exception {
                 expression,
                 PointAt(current),
                 "An alternation can not be used inside an optional",
-                "You can use '\\/' to escape the '/'"
+                "If you did not mean to use an alternation you can use '\\/' to escape the '/'. Otherwise rephrase your expression or consider using a regular expression instead."
         ));
     }
 

--- a/go/errors.go
+++ b/go/errors.go
@@ -34,7 +34,7 @@ func createAlternationNotAllowedInOptional(expression string, current token) err
 		expression,
 		pointAtToken(current),
 		"An alternation can not be used inside an optional",
-		"You can use '\\/' to escape the '/'",
+		"If you did not mean to use an alternation you can use '\\/' to escape the '/'. Otherwise rephrase your expression or consider using a regular expression instead.",
 	))
 }
 

--- a/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionException.java
+++ b/java/src/main/java/io/cucumber/cucumberexpressions/CucumberExpressionException.java
@@ -34,7 +34,7 @@ public class CucumberExpressionException extends RuntimeException {
                 expression,
                 pointAt(current),
                 "An alternation can not be used inside an optional",
-                "You can use '\\/' to escape the '/'"
+                "If you did not mean to use an alternation you can use '\\/' to escape the '/'. Otherwise rephrase your expression or consider using a regular expression instead."
         ));
     }
 

--- a/javascript/src/Errors.ts
+++ b/javascript/src/Errors.ts
@@ -115,7 +115,7 @@ export function createAlternationNotAllowedInOptional(expression: string, curren
       expression,
       pointAtLocated(current),
       'An alternation can not be used inside an optional',
-      "You can use '\\/' to escape the '/'"
+      "If you did not mean to use an alternation you can use '\\/' to escape the '/'. Otherwise rephrase your expression or consider using a regular expression instead."
     )
   )
 }

--- a/python/cucumber_expressions/errors.py
+++ b/python/cucumber_expressions/errors.py
@@ -140,7 +140,10 @@ class AlternationNotAllowedInOptional(CucumberExpressionError):
                 expression=expression,
                 pointer=point_at_located(current),
                 problem="An alternation can not be used inside an optional",
-                solution="You can use '\\/' to escape the '/'",
+                solution=(
+                    "If you did not mean to use an alternation you can use '\\/' to escape the '/'. "
+                    "Otherwise rephrase your expression or consider using a regular expression instead."
+                ),
             )
         )
 

--- a/ruby/lib/cucumber/cucumber_expressions/errors.rb
+++ b/ruby/lib/cucumber/cucumber_expressions/errors.rb
@@ -158,7 +158,7 @@ module Cucumber
             expression,
             point_at_located(current),
             'An alternation can not be used inside an optional',
-            "You can use '\\/' to escape the '/'"
+            "If you did not mean to use an alternation you can use '\\/' to escape the '/'. Otherwise rephrase your expression or consider using a regular expression instead."
           )
         )
       end

--- a/testdata/cucumber-expression/matching/does-not-allow-alternation-in-optional.yaml
+++ b/testdata/cucumber-expression/matching/does-not-allow-alternation-in-optional.yaml
@@ -7,4 +7,4 @@ exception: |-
   three( brown/black) mice
               ^
   An alternation can not be used inside an optional.
-  You can use '\/' to escape the '/'
+  If you did not mean to use an alternation you can use '\/' to escape the '/'. Otherwise rephrase your expression or consider using a regular expression instead.


### PR DESCRIPTION
### 🤔 What's changed?

Updated error message for an alternation inside an optional from...

```console
An alternation can not be used inside an optional
You can use '\\/' to escape the '/'
```

...to...

```console
An alternation can not be used inside an optional
If you did not mean to use an alternation you can use '\\/' to escape the '/'. Otherwise rephrase your expression or consider using a regular expression instead.
```

### ⚡️ What's your motivation? 

1. Improve error message consistency
    - Was `You can use '\\/' to escape the '/'`; while `AlternativeMayNotBeEmpty` message for similar is `If you did not mean to use an alternative you can use '\\/' to escape the '/'`
2. Improve clarity on how to fix if user intention was indeed to use an alternation and an optional. With `d(a/o)`, fixes would be:
    - `d(a\/o)` - if wanted `d` and `da/o`
    - `d/da/do`, `d(a)/do` or `d(a)/d(o)` - if wanted `d`, `da` and `do`
    - or to perhaps use a regular expression

Allows to close cucumber/vscode#142 by improving clarity that message is expected behaviour - so is not re-raised.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Whether `Otherwise rephrase your expression or consider using a regular expression instead.` portion is clear or can be improved.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.