### PR TITLE
Add Ruby 3.3 and Ruby next to matrix

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', 'ruby-head']
         include:
           - os: windows-latest
             ruby: '3.2'


### PR DESCRIPTION
### 🤔 What's changed?

Add the recently released Ruby 3.3 and Ruby next to matrix

### ⚡️ What's your motivation? 

Some weird failures happen with ruby-head https://github.com/rspec/rspec-mocks/actions/runs/7659693178/job/20875374161?pr=1477

Apparently, `bigdecimal` now needs to be explicitly declared as a dependency in ruby-head

To check that, we need a ruby-head build.

### 🏷️ What kind of change is this?

- :support:

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
