### PR TITLE
Explicitly declare bigdecimal as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Removed repeated 'the' from error message for use of alternations inside optionals ([#252](https://github.com/cucumber/cucumber-expressions/issues/252))
 - [Python] Missing keyword argument defaults in parameter type class ([#259](https://github.com/cucumber/cucumber-expressions/pull/259))
+- [Ruby] Added an explicit dependency on `bigdecimal` gem, to fix Ruby 3.4-pre builds where the gem has changed its status from default to bundled ([#273](https://github.com/cucumber/cucumber-expressions/pull/273))
 
 ## [17.0.1] - 2023-11-24
 ### Fixed

--- a/ruby/cucumber-cucumber-expressions.gemspec
+++ b/ruby/cucumber-cucumber-expressions.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/cucumber/common/blob/main/cucumber-expressions/ruby',
   }
 
+  s.add_runtime_dependency 'bigdecimal'
+
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   s.add_development_dependency 'rspec', '~> 3.11', '>= 3.11.0'
   s.add_development_dependency 'rubocop', '~> 1.27.0'


### PR DESCRIPTION

### 🤔 What's changed?

`bigdecimal` is now declared as a dependency

### ⚡️ What's your motivation? 

https://github.com/rspec/rspec-mocks/actions/runs/7659693178/job/20875374161?pr=1477
```
/home/runner/work/rspec-mocks/rspec-mocks/bundle/ruby/3.4.0+0/gems/cucumber-cucumber-expressions-17.0.1/lib/cucumber/cucumber_expressions/parameter_type_registry.rb:6:in `require': cannot load such file -- bigdecimal (LoadError)
	from /home/runner/work/rspec-mocks/rspec-mocks/bundle/ruby/3.4.0+0/gems/cucumber-cucumber-expressions-17.0.1/lib/cucumber/cucumber_expressions/parameter_type_registry.rb:6:in `<top (required)>'
```

⚠️ https://github.com/cucumber/cucumber-expressions/pull/272 needs to be merged first? Or we should see a failure there in ruby-head.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
