### PR TITLE
Reassociate .NET README note on parameter type name

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ public Color ConvertColor(string colorValue)
 }
 ```
 
+*Note: Currently the parameter name cannot be customized, so the custom parameters can only be used with the type name, e.g. `{Color}`.*
+
 #### Python
 
 ```python
@@ -166,8 +168,6 @@ ParameterType(
   transformer= lambda s: Color(),
 )
 ```
-
-*Note: Currently the parameter name cannot be customized, so the custom parameters can only be used with the type name, e.g. `{Color}`.*
 
 ## Optional text
 


### PR DESCRIPTION
### 🤔 What's changed?

<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

Text was originally [added as additional documentation for the .NET implementation](https://github.com/cucumber/cucumber-expressions/commit/aa6fea8bfce3254185a2215c820008b18c3a002e).

When Python support was added (#65), the Python README example was added between the .NET code example and the .NET footnote.

This creates a source of confusion, as it now appears associated with the Python example - which is incorrect.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

- Whether this is globally applicable? i.e. that "custom parameters can only be used with the type name" e.g. `Color` for `.NET`, `color` for Python, etc.
  - If so, whether note should be made generic and moved to global scope - rather than only a specific language implementation?

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)