### PR TITLE
Update links in Ruby gemspec.

### DIFF
--- a/ruby/cucumber-cucumber-expressions.gemspec
+++ b/ruby/cucumber-cucumber-expressions.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'bug_tracker_uri' => 'https://github.com/cucumber/cucumber/issues',
-    'changelog_uri' => 'https://github.com/cucumber/common/blob/main/cucumber-expressions/CHANGELOG.md',
-    'documentation_uri' => 'https://cucumber.io/docs/cucumber/cucumber-expressions/',
-    'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/cukes',
-    'source_code_uri' => 'https://github.com/cucumber/common/blob/main/cucumber-expressions/ruby',
+    'changelog_uri' => 'https://github.com/cucumber/cucumber-expressions/blob/main/CHANGELOG.md',
+    'documentation_uri' => 'https://github.com/cucumber/cucumber-expressions#readme',
+    'mailing_list_uri' => 'https://community.smartbear.com/category/cucumber/discussions/cucumberos',
+    'source_code_uri' => 'https://github.com/cucumber/cucumber-expressions/tree/main/ruby',
   }
 
   s.add_runtime_dependency 'bigdecimal'


### PR DESCRIPTION
### 🤔 What's changed?

More links were updated from old ones.

<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

Don't get 404 or get told that the content is elsewhere (this is the situation with docs uri) when following links from [rubygems.org](https://rubygems.org/gems/cucumber-cucumber-expressions) or the gemspec itself
<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

:bank:
<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Are all the links OK? I just followed the redirects and entered URIs in gemspec.

is `bug_tracker_uri` supposed to point to the main cucumber/cucumber repo?
<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
