### PR TITLE
Remove support for Python 3.7 and extend support to 3.12 

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - os: windows-latest
             python-version: "3.10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [Python] Revert support for Python 3.8 and 3.9; and extend support to 3.12 ([#280](https://github.com/cucumber/cucumber-expressions/pull/280))
 
 ## [17.0.2] - 2024-02-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
-- [Python] Revert support for Python 3.8 and 3.9; and extend support to 3.12 ([#280](https://github.com/cucumber/cucumber-expressions/pull/280))
+- [Python] Remove support for Python 3.7 and extend support to 3.12 ([#280](https://github.com/cucumber/cucumber-expressions/pull/280))
 
 ## [17.0.2] - 2024-02-20
 ### Changed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,6 +29,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Testing",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -38,7 +37,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.8"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^3.3"
@@ -50,7 +49,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.isort]
-py_version = 37
+py_version = 38
 profile = "black"
 force_single_line = true
 combine_as_imports = true
@@ -60,4 +59,4 @@ src_paths = ["cucumber_expressions", "tests"]
 
 
 [tool.black]
-target-version = ['py37']
+target-version = ['py38']


### PR DESCRIPTION
### 🤔 What's changed?

Reverted required Python versions from 3.10+ back to 3.8+. Removed Python 3.7.

Added pipeline testing against Python 3.11 and 3.12.

### ⚡️ What's your motivation? 

Support [officially supported Python distributions](https://devguide.python.org/versions/), re-enabling 3.8 and 3.9; to support users appropriately.

```console
➜  repository (main) python3.9 -m pip install cucumber-expressions==17.0.2
ERROR: Ignored the following versions that require a different python version: 17.0.1 Requires-Python >=3.10,<4.0; 17.0.2 Requires-Python >=3.10,<4.0
ERROR: Could not find a version that satisfies the requirement cucumber-expressions==17.0.2 (from versions: 16.0.0, 16.0.1, 16.1.0, 16.1.1, 16.1.2)
ERROR: No matching distribution found for cucumber-expressions==17.0.2
```

Fixes that test jobs with 3.8 and 3.9 were incorrectly running 3.10.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Python 3.7 was not being tested in the pipeline, is unsupported by our version of [Poetry](https://python-poetry.org/docs/#system-requirements) and has [reached End of Life](https://devguide.python.org/versions/). Have removed support, let me know if any feedback on that decision.

If the activated Python version in the test job is below the required version of the package, poetry falls back on other installed versions (in this case 3.10). This presents a risk as the pipeline will pass if the required Python version is bumped and not failing for older Python versions still in the pipeline.

```console
The currently activated Python version 3.8.18 is not supported by the project (^3.10).
Trying to find and use a compatible version. 
Using python3.10 (3.10.12)
```

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [CHANGELOG](https://github.com/cucumber/cucumber-expressions/blob/main/CHANGELOG.md), linking to this pull request.