### PR TITLE
python: optional transformer argument for parameter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - [Python] Remove support for Python 3.7 and extend support to 3.12 ([#280](https://github.com/cucumber/cucumber-expressions/pull/280))
+- [Python] The `ParameterType` constructor's `transformer` should be optional ([#288](https://github.com/cucumber/cucumber-expressions/pull/288))
 
 ## [17.0.2] - 2024-02-20
 ### Changed

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ ParameterType(
   name=        "color",
   regexp=      "red|blue|yellow",
   type=        Color,
-  transformer= lambda s: Color(),
+  transformer= lambda s: Color(s),
 )
 ```
 

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,3 +1,4 @@
+__pycache__
 venv/
 # Pytest
 .pytest_cache

--- a/python/cucumber_expressions/parameter_type.py
+++ b/python/cucumber_expressions/parameter_type.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Pattern
+from typing import Callable, Optional, Pattern
 
 from cucumber_expressions.errors import CucumberExpressionError
 
@@ -47,7 +47,7 @@ class ParameterType:
         name,
         regexp,
         type,
-        transformer,
+        transformer: Optional[Callable] = None,
         use_for_snippets: bool = True,
         prefer_for_regexp_match: bool = False,
     ):
@@ -69,7 +69,7 @@ class ParameterType:
         if self.name:
             self._check_parameter_type_name(self.name)
         self.type = type
-        self.transformer = transformer
+        self.transformer = transformer or (lambda value: type(value))
         self._use_for_snippets = use_for_snippets
         self._prefer_for_regexp_match = prefer_for_regexp_match
         self.regexps = self.to_array(regexp)

--- a/python/tests/test_custom_parameter_type.py
+++ b/python/tests/test_custom_parameter_type.py
@@ -62,6 +62,23 @@ class TestCustomParameterType:
         transformed_argument_value = expression.match("I have a red ball")[0]
         assert transformed_argument_value.value == Color("red")
 
+    def test_casts_to_type_without_transformer(
+        self,
+    ):
+        parameter_type_registry = ParameterTypeRegistry()
+        parameter_type_registry.define_parameter_type(
+            ParameterType(
+                "color",
+                r"red|blue|yellow",
+                Color,
+            )
+        )
+        expression = CucumberExpression(
+            "I have a {color} ball", parameter_type_registry
+        )
+        argument_value = expression.match("I have a red ball")[0].value
+        assert argument_value == Color("red")
+
     def test_matches_parameters_without_snippet_and_regex_parameters(
         self,
     ):


### PR DESCRIPTION
### 🤔 What's changed?

- Made the Cucumber Expressions parameter type optional with the Python implementation

### ⚡️ What's your motivation? 

- Matches the JavaScript implementation of casting to `type` by default if a transformer is not explicitly specified (see cucumber/cucumber-expressions#178)
- Improves user experience, removing a common use case to simply cast to the type - without further transformation. This improves code quality and maintainability.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.