### PR TITLE
Python: Replace publish action

### DIFF
--- a/.github/workflows/release-pypi.yaml
+++ b/.github/workflows/release-pypi.yaml
@@ -2,7 +2,7 @@ name: Release Python
 
 on:
   push:
-    branches: [release/*]
+    branches: [ release/* ]
 
 jobs:
   release:
@@ -21,6 +21,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - uses: cucumber/action-publish-pypi@v3.0.0
+
+      - name: Show Python version
+        run: python --version
+
+      - name: Install Python package dependencies
+        run: |
+          python -m pip install build twine
+          python -m build
+          twine check --strict dist/*
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          working-directory: "python"
+          packages-dir: python/dist

--- a/.github/workflows/release-pypi.yaml
+++ b/.github/workflows/release-pypi.yaml
@@ -25,11 +25,12 @@ jobs:
       - name: Show Python version
         run: python --version
 
-      - name: Install Python package dependencies
+      - name: Check build
         run: |
           python -m pip install build twine
           python -m build
           twine check --strict dist/*
+
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/release-pypi.yaml
+++ b/.github/workflows/release-pypi.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Show Python version
         run: python --version
 
-      - name: Check build
+      - name: Build package
         run: |
           python -m pip install build twine
           python -m build


### PR DESCRIPTION


### 🤔 What's changed?

Replaces `cucumber/action-publish-pypi` with
`pypa/gh-action-pypi-publish@release/v1`. The motivation for using actions in the cucumber org is to ensure that we do not hand release tokens to untrusted code. As the party publishing our python packages, the Python Package Authority can be trusted. Additionally, their action uses trusted publishers which authorizes GitHub with OIDC so no long-lived tokens are used.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
