### PR TITLE
Replace deprecated `::set-output`

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -57,7 +57,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Get full Python version
       id: full-python-version
-      run: echo "version={$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")}" >> $GITHUB_OUTPUT
+      run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
     - name: Bootstrap poetry
       run: |
         curl -sL https://install.python-poetry.org | python - -y ${{ matrix.bootstrap-args }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -57,7 +57,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Get full Python version
       id: full-python-version
-      run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+      run: echo "version={$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")}" >> $GITHUB_OUTPUT
     - name: Bootstrap poetry
       run: |
         curl -sL https://install.python-poetry.org | python - -y ${{ matrix.bootstrap-args }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-### Changed
-- [CI] Replace deprecated `::set-output`
 
 ## [18.0.1] - 2024-10-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- [CI] Replace deprecated `::set-output`
 
 ## [18.0.1] - 2024-10-28
 ### Fixed


### PR DESCRIPTION
### 🤔 What's changed?

As per the deprecation warning and explanation at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### ⚡️ What's your motivation? 

See https://github.com/cucumber/common/issues/2150

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Is the changelog entry fine this way?

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
