### PR TITLE
Use newer dotnet versions for testing

### DIFF
--- a/.github/workflows/release-nuget.yaml
+++ b/.github/workflows/release-nuget.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - uses: cucumber/action-publish-nuget@v1.0.0
         with:
           nuget-api-key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            8.0.x
+            9.0.x
       - name: Restore dependencies
         run: dotnet restore
         working-directory: dotnet

--- a/dotnet/CucumberExpressions.Tests/CucumberExpressions.Tests.csproj
+++ b/dotnet/CucumberExpressions.Tests/CucumberExpressions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion> 
     <IsPackable>false</IsPackable>
 	<SignAssembly>True</SignAssembly>


### PR DESCRIPTION
### 🤔 What's changed?

Change the GitHub Actions workflows to use dotnet 8.0 and 9.0, [in keeping with Gherkin](https://github.com/cucumber/gherkin/blob/main/.github/workflows/test-dotnet.yml#L27-L30) among other repos.

### ⚡️ What's your motivation? 

Unblocks some dependency upgrades e.g. https://github.com/cucumber/cucumber-expressions/pull/341

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
