### PR TITLE
Don't match solitary minus sign as a double

### DIFF
--- a/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
+++ b/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
@@ -27,7 +27,7 @@ public final class ParameterTypeRegistry {
             Pattern.compile("\\d+").pattern()
     );
     private static final String SIGN = "[-+]?";
-    private static final String MUST_CONTAIN_NUMBER = "(?=.*\\d.*)";
+    private static final String MUST_CONTAIN_NUMBER = "(?=\\S*\\d\\S*)";
     private static final String SCIENTIFIC_NUMBER = "(?:\\d+[{expnt}]-?\\d+)?";
     private static final String DECIMAL_FRACTION = "(?:[{decimal}](?=\\d.*))?\\d*";
     private static final String INTEGER = "(?:\\d+(?:[{group}]?\\d+)*)*";

--- a/testdata/cucumber-expression/matching/does-not-match-single-minus-as-double.yaml
+++ b/testdata/cucumber-expression/matching/does-not-match-single-minus-as-double.yaml
@@ -1,0 +1,4 @@
+---
+expression: '{double}'
+text: '-'
+expected_args:

--- a/testdata/cucumber-expression/matching/does-not-match-single-minus-as-int.yaml
+++ b/testdata/cucumber-expression/matching/does-not-match-single-minus-as-int.yaml
@@ -1,0 +1,4 @@
+---
+expression: '{int}'
+text: '-'
+expected_args:

--- a/testdata/cucumber-expression/matching/matches-float-negative.yaml
+++ b/testdata/cucumber-expression/matching/matches-float-negative.yaml
@@ -1,0 +1,5 @@
+---
+expression: "{float}"
+text: '-3.141593'
+expected_args:
+- -3.141593

--- a/testdata/cucumber-expression/matching/matches-int-negative.yaml
+++ b/testdata/cucumber-expression/matching/matches-int-negative.yaml
@@ -1,0 +1,5 @@
+---
+expression: "{int}"
+text: '-2147483647'
+expected_args:
+- -2147483647


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Given a scenario:

```
Feature: Custom parameters

  Scenario: example
    Given I read chapters 1 - 15 'Pride and Prejudice'
```

The solitary minus sign should not match with the `{double}` parameter type. This effectively means that floating point numbers can not contain whitespace. Which seems true for most reasonable number representations.

Fixes: #328

### 🏷️ What kind of change is this?
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
