### PR TITLE
Use trusted publishing for Ruby

### DIFF
--- a/.github/workflows/release-rubygem.yaml
+++ b/.github/workflows/release-rubygem.yaml
@@ -4,21 +4,26 @@ permissions: {}
 
 on:
   push:
-    branches: [release/*]
+    branches:
+      - release/*
 
 jobs:
   publish-rubygem:
     name: Publish Ruby Gem
     runs-on: ubuntu-latest
     environment: Release
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1.307.0
         with:
-          ruby-version: '3.4.9'
-      - uses: cucumber/action-publish-rubygem@d8918cbdee789cfc78f346a96a59596b87795be1 # v1.0.0
+          ruby-version: 4.0.3
+          working-directory: ruby
+      - uses: rubygems/configure-rubygems-credentials@762a4b77c3300434bb57c7ce80b20e36231927aa # v2.0.0
+      - uses: cucumber/action-publish-rubygem@4e79bb9aed597c835e8438f57c04d0996ab80d72 # v2.0.0
         with:
-          rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}
-          working_directory: ruby
+          working-directory: ruby


### PR DESCRIPTION
### 🤔 What's changed?

The `configure-rubygems-credentials` actions logs in on RubyGems using
OIDC. The `cucumber/action-publish-rubygem` action then publishes using
those credentials.

Additionally (where applicable):

1. Use `ruby/setup-ruby` with Ruby 4.0.3 to make releases
2. Rename file to `.yaml` for consistency (file name matters for OIDC!)
3. Rename action to Release RubyGems for accuracy

### ⚡️ What's your motivation? 

Work towards closing https://github.com/cucumber/common/issues/2277.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [x] Remove `RUBYGEMS_API_KEY` from secrets
- [x] Remove API Key configuration from Rubygems
- [x] Configure trusted publisher in Rubygems
- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
