### PR TITLE
Fix codepoint offsets in .NET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [.Net] Fix codepoint offsets for tokens ([#440](https://github.com/cucumber/cucumber-expressions/pull/440))
 
 ## [20.0.0] - 2026-06-11
 ### Changed

--- a/dotnet/CucumberExpressions/Ast/Token.cs
+++ b/dotnet/CucumberExpressions/Ast/Token.cs
@@ -24,9 +24,9 @@ public class Token : ILocated
         End = end;
     }
 
-    public static bool CanEscape(char token)
+    public static bool CanEscape(int token)
     {
-        if (char.IsWhiteSpace(token))
+        if (IsWhiteSpace(token))
         {
             return true;
         }
@@ -45,9 +45,9 @@ public class Token : ILocated
         return false;
     }
 
-    public static TokenType TypeOf(char token)
+    public static TokenType TypeOf(int token)
     {
-        if (char.IsWhiteSpace(token))
+        if (IsWhiteSpace(token))
         {
             return TokenType.WHITE_SPACE;
         }
@@ -72,6 +72,13 @@ public class Token : ILocated
     public static bool IsEscapeCharacter(int token)
     {
         return token == EscapeCharacter;
+    }
+
+    // char.IsWhiteSpace only accepts a UTF-16 code unit. No codepoint outside
+    // the BMP is whitespace, so anything that needs a surrogate pair is not.
+    private static bool IsWhiteSpace(int codePoint)
+    {
+        return codePoint <= char.MaxValue && char.IsWhiteSpace((char)codePoint);
     }
 
     public override string ToString()

--- a/dotnet/CucumberExpressions/CucumberExpressionException.cs
+++ b/dotnet/CucumberExpressions/CucumberExpressionException.cs
@@ -35,7 +35,7 @@ public class CucumberExpressionException : Exception {
     }
 
     internal static CucumberExpressionException CreateTheEndOfLineCanNotBeEscaped(string expression) {
-        int index = expression.Length - 1;
+        int index = CodePointCount(expression) - 1;
         return new CucumberExpressionException(GetMessage(
                 index,
                 expression,
@@ -88,6 +88,19 @@ public class CucumberExpressionException : Exception {
                 PointAt(node),
                 "An alternative may not exclusively contain optionals",
                 "If you did not mean to use an optional you can use '\\(' to escape the '('"));
+    }
+
+    // The caret index is a codepoint offset; string.Length counts UTF-16 code
+    // units, which is one too many for every character outside the BMP.
+    private static int CodePointCount(string expression) {
+        int count = 0;
+        for (int i = 0; i < expression.Length; i++) {
+            if (char.IsHighSurrogate(expression[i]) && i + 1 < expression.Length && char.IsLowSurrogate(expression[i + 1])) {
+                i++;
+            }
+            count++;
+        }
+        return count;
     }
 
     private static string ThisCucumberExpressionHasAProblemAt(int index) {

--- a/dotnet/CucumberExpressions/Parsing/CucumberExpressionTokenizer.cs
+++ b/dotnet/CucumberExpressions/Parsing/CucumberExpressionTokenizer.cs
@@ -24,9 +24,10 @@ public class CucumberExpressionTokenizer
     private class TokenIterator
     {
         private readonly string _expression;
-        private readonly IEnumerator<char> _codePoints;
+        private readonly IEnumerator<int> _codePoints;
 
         private StringBuilder _buffer = new();
+        private int _bufferCodePointCount;
         private TokenType _previousTokenType = TokenType.UNKNOWN;
         private TokenType _currentTokenType = TokenType.START_OF_LINE;
         private bool _treatAsText;
@@ -36,7 +37,7 @@ public class CucumberExpressionTokenizer
         public TokenIterator(string expression)
         {
             _expression = expression;
-            _codePoints = expression.GetEnumerator();
+            _codePoints = CodePointsOf(expression).GetEnumerator();
         }
 
         private Token ConvertBufferToToken(TokenType tokenType)
@@ -47,11 +48,18 @@ public class CucumberExpressionTokenizer
                 escapeTokens = _escaped;
                 _escaped = 0;
             }
-            int consumedIndex = _bufferStartIndex + _buffer.Length + escapeTokens;
+            int consumedIndex = _bufferStartIndex + _bufferCodePointCount + escapeTokens;
             Token t = new Token(_buffer.ToString(), tokenType, _bufferStartIndex, consumedIndex);
             _buffer = new StringBuilder();
+            _bufferCodePointCount = 0;
             this._bufferStartIndex = consumedIndex;
             return t;
+        }
+
+        private void AppendCodePoint(int codePoint)
+        {
+            _buffer.Append(char.ConvertFromUtf32(codePoint));
+            _bufferCodePointCount++;
         }
 
         private void AdvanceTokenTypes()
@@ -60,7 +68,7 @@ public class CucumberExpressionTokenizer
             _currentTokenType = TokenType.UNKNOWN;
         }
 
-        private TokenType TokenTypeOf(char token, bool treatAsText)
+        private TokenType TokenTypeOf(int token, bool treatAsText)
         {
             if (!treatAsText)
             {
@@ -70,7 +78,29 @@ public class CucumberExpressionTokenizer
             {
                 return TokenType.TEXT;
             }
-            throw CucumberExpressionException.CreateCantEscape(_expression, _bufferStartIndex + _buffer.Length + _escaped);
+            throw CucumberExpressionException.CreateCantEscape(_expression, _bufferStartIndex + _bufferCodePointCount + _escaped);
+        }
+
+        // Offsets are codepoint offsets, so the expression has to be walked a
+        // codepoint at a time. A plain foreach over a string yields UTF-16 code
+        // units, which counts anything outside the BMP twice. netstandard2.0
+        // has no EnumerateRunes, hence the manual surrogate pairing.
+        private static IEnumerable<int> CodePointsOf(string expression)
+        {
+            for (int i = 0; i < expression.Length; i++)
+            {
+                if (char.IsHighSurrogate(expression[i])
+                    && i + 1 < expression.Length
+                    && char.IsLowSurrogate(expression[i + 1]))
+                {
+                    yield return char.ConvertToUtf32(expression[i], expression[i + 1]);
+                    i++;
+                }
+                else
+                {
+                    yield return expression[i];
+                }
+            }
         }
 
         private bool ShouldContinueTokenType(TokenType? previousTokenType, TokenType? currentTokenType)
@@ -99,7 +129,7 @@ public class CucumberExpressionTokenizer
 
             while (_codePoints.MoveNext())
             {
-                char codePoint = _codePoints.Current;
+                int codePoint = _codePoints.Current;
                 if (!_treatAsText && Token.IsEscapeCharacter(codePoint))
                 {
                     _escaped++;
@@ -113,18 +143,18 @@ public class CucumberExpressionTokenizer
                         ShouldContinueTokenType(_previousTokenType, _currentTokenType))
                 {
                     AdvanceTokenTypes();
-                    _buffer.Append(codePoint);
+                    AppendCodePoint(codePoint);
                 }
                 else
                 {
                     Token t = ConvertBufferToToken(_previousTokenType);
                     AdvanceTokenTypes();
-                    _buffer.Append(codePoint);
+                    AppendCodePoint(codePoint);
                     return t;
                 }
             }
 
-            if (_buffer.Length > 0)
+            if (_bufferCodePointCount > 0)
             {
                 Token previousToken = ConvertBufferToToken(_previousTokenType);
                 AdvanceTokenTypes();

--- a/testdata/cucumber-expression/parser/astral-plane-character.yaml
+++ b/testdata/cucumber-expression/parser/astral-plane-character.yaml
@@ -1,0 +1,23 @@
+---
+expression: "😀 {int}"
+expected_ast:
+  type: EXPRESSION_NODE
+  start: 0
+  end: 7
+  nodes:
+  - type: TEXT_NODE
+    start: 0
+    end: 1
+    token: "😀"
+  - type: TEXT_NODE
+    start: 1
+    end: 2
+    token: " "
+  - type: PARAMETER_NODE
+    start: 2
+    end: 7
+    nodes:
+    - type: TEXT_NODE
+      start: 3
+      end: 6
+      token: int

--- a/testdata/cucumber-expression/tokenizer/astral-plane-character.yaml
+++ b/testdata/cucumber-expression/tokenizer/astral-plane-character.yaml
@@ -1,0 +1,31 @@
+---
+expression: "😀 {int}"
+expected_tokens:
+- type: START_OF_LINE
+  start: 0
+  end: 0
+  text: ''
+- type: TEXT
+  start: 0
+  end: 1
+  text: "😀"
+- type: WHITE_SPACE
+  start: 1
+  end: 2
+  text: " "
+- type: BEGIN_PARAMETER
+  start: 2
+  end: 3
+  text: "{"
+- type: TEXT
+  start: 3
+  end: 6
+  text: int
+- type: END_PARAMETER
+  start: 6
+  end: 7
+  text: "}"
+- type: END_OF_LINE
+  start: 7
+  end: 7
+  text: ''


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

The .NET implementation now reports offsets consistently for astral-plane characters (emoji).

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

Consistency and correctness across implementations

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

Do we need to make it more explicit in docs that offsets are *codepoint* offsets?

FYI: The bug was discovered and fixed by Claude Opus 4.8, and I *do* understand all the code 😉.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
