### PR TITLE
Improve support for scientific notation floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- [.Net] Fix codepoint offsets for tokens ([#440](https://github.com/cucumber/cucumber-expressions/pull/440))
+- Support a positive exponent in scientific notation floats, e.g. `1.5E+3` ([#441](https://github.com/cucumber/cucumber-expressions/pull/441))
+- [Java] Support a leading `+` sign in `{float}`, `{double}` and `{bigdecimal}` ([#441](https://github.com/cucumber/cucumber-expressions/pull/441))
 
 ## [20.0.0] - 2026-06-11
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- [.Net] Fix codepoint offsets for tokens ([#440](https://github.com/cucumber/cucumber-expressions/pull/440))
+
 ## [20.0.0] - 2026-06-11
 ### Changed
 - [JavaScript] BREAKING CHANGE: Switch to ESM ([#431](https://github.com/cucumber/cucumber-expressions/pull/431))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Support a positive exponent in scientific notation floats, e.g. `1.5E+3` ([#441](https://github.com/cucumber/cucumber-expressions/pull/441))
 - [Java] Support a leading `+` sign in `{float}`, `{double}` and `{bigdecimal}` ([#441](https://github.com/cucumber/cucumber-expressions/pull/441))
+- [Ruby,Go,JavaScript,Python] More performant float regex pattern ([#441](https://github.com/cucumber/cucumber-expressions/pull/441))
 
 ## [20.0.0] - 2026-06-11
 ### Changed

--- a/dotnet/CucumberExpressions.Tests/CucumberExpressionTest.cs
+++ b/dotnet/CucumberExpressions.Tests/CucumberExpressionTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Globalization;
 using System.Linq;
 using AwesomeAssertions;
 using Xunit;
@@ -40,10 +41,9 @@ public class CucumberExpressionTest : CucumberExpressionTestBase
             _testOutputHelper.WriteLine(expression.Regex.ToString());
             var match = MatchExpression(expression, expectation.text);
 
-            var values = match == null ? null : match
-                .ToList();
+            var values = match?.Select(Canonical).ToList();
 
-            Assert.Equal(expectation.expected_args, values);
+            Assert.Equal(expectation.expected_args?.Select(Canonical).ToList(), values);
         }
         else
         {
@@ -55,6 +55,22 @@ public class CucumberExpressionTest : CucumberExpressionTestBase
                 .Should().Throw<CucumberExpressionException>().WithMessage(expectation.exception);
         }
     }
+
+    // expected_args arrive from YAML as strings. Round both sides through the
+    // same numeric normalisation so 1500.0 and 1500 are not spuriously unequal.
+    private static string Canonical(object value)
+        => value switch
+        {
+            null => null,
+            double d => d.ToString("R", CultureInfo.InvariantCulture),
+            // Format the float directly; widening to double would expose
+            // single-precision noise (3.141593f becomes 3.1415929794311523).
+            float f => f.ToString("R", CultureInfo.InvariantCulture),
+            int i => i.ToString(CultureInfo.InvariantCulture),
+            string s when double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+                => parsed.ToString("R", CultureInfo.InvariantCulture),
+            _ => value.ToString()
+        };
 
     public class Expectation
     {

--- a/dotnet/CucumberExpressions.Tests/CucumberExpressionTestBase.cs
+++ b/dotnet/CucumberExpressions.Tests/CucumberExpressionTestBase.cs
@@ -79,31 +79,14 @@ public abstract class CucumberExpressionTestBase : TestBase
         return s;
     }
 
-    /// <summary>
-    /// Matches <paramref name="text"/> and converts each captured group to the
-    /// CLR type its parameter type declares.
-    /// </summary>
-    /// <remarks>
-    /// This library stops at "here is a regex and here are the parameter types"
-    /// and leaves argument conversion to the consumer, so the conversion has to
-    /// live here. It used to be simulated with string manipulation — a leading
-    /// "." was turned into "0." rather than parsed — which meant the acceptance
-    /// suite never exercised anything a real number parser would do.
-    ///
-    /// Group-to-parameter alignment is 1:1: GetParameterTypeRegexps runs every
-    /// parameter type regexp through RegexCaptureGroupRemover, so a parameter
-    /// contributes exactly one capture group however many its regexp declares.
-    /// </remarks>
     public object[] MatchExpression(IExpression expression, string text)
     {
         var group = new TreeRegexp(expression.Regex).Match(text);
         if (group == null)
             return null;
 
-        // A RegularExpression has no parameter types; its groups stay strings.
         var parameterTypes = (expression as CucumberExpression)?.ParameterTypes;
 
-        // Children is null when the expression captures nothing.
         var argGroups = group.Children ?? new List<Parsing.Group>();
 
         return argGroups

--- a/dotnet/CucumberExpressions.Tests/CucumberExpressionTestBase.cs
+++ b/dotnet/CucumberExpressions.Tests/CucumberExpressionTestBase.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using CucumberExpressions.Parsing;
 
 namespace CucumberExpressions.Tests;
 
@@ -77,17 +79,52 @@ public abstract class CucumberExpressionTestBase : TestBase
         return s;
     }
 
-    public string[] MatchExpression(IExpression expression, string text)
+    /// <summary>
+    /// Matches <paramref name="text"/> and converts each captured group to the
+    /// CLR type its parameter type declares.
+    /// </summary>
+    /// <remarks>
+    /// This library stops at "here is a regex and here are the parameter types"
+    /// and leaves argument conversion to the consumer, so the conversion has to
+    /// live here. It used to be simulated with string manipulation — a leading
+    /// "." was turned into "0." rather than parsed — which meant the acceptance
+    /// suite never exercised anything a real number parser would do.
+    ///
+    /// Group-to-parameter alignment is 1:1: GetParameterTypeRegexps runs every
+    /// parameter type regexp through RegexCaptureGroupRemover, so a parameter
+    /// contributes exactly one capture group however many its regexp declares.
+    /// </remarks>
+    public object[] MatchExpression(IExpression expression, string text)
     {
-        var match = expression.Regex.Match(text);
-        if (!match.Success)
+        var group = new TreeRegexp(expression.Regex).Match(text);
+        if (group == null)
             return null;
-        return match.Groups.OfType<System.Text.RegularExpressions.Group>().Skip(1)
-            .Where(g => g.Success)
-            .Select(c => c.Value)
-            .Select(v => v.StartsWith(".") ? "0" + v : v) // simulate float parsing with leading dot (.123)
-            .Select(v => v.Replace(@"\""", @"""").Replace(@"\'", @"'")) // simulate quote masking
-            .Select(TrimQuotes)
+
+        // A RegularExpression has no parameter types; its groups stay strings.
+        var parameterTypes = (expression as CucumberExpression)?.ParameterTypes;
+
+        // Children is null when the expression captures nothing.
+        var argGroups = group.Children ?? new List<Parsing.Group>();
+
+        return argGroups
+            .Select((g, i) => ConvertGroup(g, i < (parameterTypes?.Length ?? 0) ? parameterTypes[i] : null))
             .ToArray();
+    }
+
+    private object ConvertGroup(Parsing.Group group, IParameterType parameterType)
+    {
+        var value = group.Value;
+        if (value == null)
+            return null;
+
+        var targetType = parameterType?.ParameterType;
+        if (targetType == typeof(int))
+            return int.Parse(value, CultureInfo.InvariantCulture);
+        if (targetType == typeof(float))
+            return float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+        if (targetType == typeof(double))
+            return double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+
+        return TrimQuotes(value.Replace(@"\""", @"""").Replace(@"\'", @"'"));
     }
 }

--- a/dotnet/CucumberExpressions/ParameterTypeConstants.cs
+++ b/dotnet/CucumberExpressions/ParameterTypeConstants.cs
@@ -18,7 +18,7 @@ public static class ParameterTypeConstants
     public const string DoubleParameterName = "double";
     private const string FloatPartSign = "[-+]?";
     private const string FloatPartMustContainNumber = "(?=.*\\d.*)";
-    private const string FloatPartScientificNumber = "(?:\\d+[{exponent}]-?\\d+)?";
+    private const string FloatPartScientificNumber = "(?:\\d+[{exponent}][+-]?\\d+)?";
     private const string FloatPartDecimalFraction = "(?:[{decimal}](?=\\d.*))?\\d*";
     private const string FloatPartInteger = "(?:\\d+(?:[{group}]?\\d+)*)*";
     public const string FloatParameterRegexTemplate = FloatPartMustContainNumber + FloatPartSign + FloatPartInteger + FloatPartDecimalFraction + FloatPartScientificNumber;

--- a/go/cucumber_expression_test.go
+++ b/go/cucumber_expression_test.go
@@ -105,8 +105,7 @@ func TestCucumberExpression(t *testing.T) {
 		require.Equal(t, MatchCucumberExpression(t, "{float}", ".1"), []interface{}{0.1})
 		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1"), []interface{}{-0.1})
 		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.10000001"), []interface{}{-0.10000001})
-		// Scientific notation, with an uppercase E as in the other
-		// implementations. strconv.ParseFloat handles every form of it.
+
 		require.Equal(t, MatchCucumberExpression(t, "{float}", ".1E1"), []interface{}{1.0})
 		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E-1"), []interface{}{-0.01})
 		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E-2"), []interface{}{-0.001})

--- a/go/cucumber_expression_test.go
+++ b/go/cucumber_expression_test.go
@@ -105,15 +105,18 @@ func TestCucumberExpression(t *testing.T) {
 		require.Equal(t, MatchCucumberExpression(t, "{float}", ".1"), []interface{}{0.1})
 		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1"), []interface{}{-0.1})
 		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.10000001"), []interface{}{-0.10000001})
+		// Scientific notation, with an uppercase E as in the other
+		// implementations. strconv.ParseFloat handles every form of it.
+		require.Equal(t, MatchCucumberExpression(t, "{float}", ".1E1"), []interface{}{1.0})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E-1"), []interface{}{-0.01})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E-2"), []interface{}{-0.001})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E+1"), []interface{}{-1.0})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E+2"), []interface{}{-10.0})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E1"), []interface{}{-1.0})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.10E2"), []interface{}{-10.0})
+		// A lowercase e is not part of the pattern in any implementation.
 		require.Equal(t, MatchCucumberExpression(t, "{float}", "1e1"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", ".1E1"), []interface{}(nil))
 		require.Equal(t, MatchCucumberExpression(t, "{float}", "E1"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E-1"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E-2"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E+1"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E+2"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E1"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.10E2"), []interface{}(nil))
 	})
 
 	t.Run("matches float with zero", func(t *testing.T) {

--- a/go/parameter_type_registry.go
+++ b/go/parameter_type_registry.go
@@ -13,7 +13,7 @@ var INTEGER_REGEXPS = []*regexp.Regexp{
 	regexp.MustCompile(`\d+`),
 }
 var FLOAT_REGEXPS = []*regexp.Regexp{
-	regexp.MustCompile(`[-+]?\d*\.?\d+`),
+	regexp.MustCompile(`[-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[E][+-]?\d+)?`),
 }
 var WORD_REGEXPS = []*regexp.Regexp{
 	regexp.MustCompile(`[^\s]+`),

--- a/java/src/main/java/io/cucumber/cucumberexpressions/NumberParser.java
+++ b/java/src/main/java/io/cucumber/cucumberexpressions/NumberParser.java
@@ -12,15 +12,13 @@ final class NumberParser {
     private final String exponentSeparator;
 
     NumberParser(Locale locale) {
-        numberFormat = DecimalFormat.getNumberInstance(locale);
-        String exponentSeparator = "E";
+        DecimalFormatSymbols symbols = KeyboardFriendlyDecimalFormatSymbols.getInstance(locale);
+        this.exponentSeparator = symbols.getExponentSeparator();
+        this.numberFormat = DecimalFormat.getNumberInstance(locale);
         if (numberFormat instanceof DecimalFormat decimalFormat) {
             decimalFormat.setParseBigDecimal(true);
-            DecimalFormatSymbols symbols = KeyboardFriendlyDecimalFormatSymbols.getInstance(locale);
             decimalFormat.setDecimalFormatSymbols(symbols);
-            exponentSeparator = symbols.getExponentSeparator();
         }
-        this.exponentSeparator = exponentSeparator;
     }
 
     double parseDouble(String s) {
@@ -41,20 +39,41 @@ final class NumberParser {
     }
 
     private Number parse(String s) {
+        int index = s.indexOf(exponentSeparator);
+        if (index < 0) {
+            return parseSignificand(s);
+        }
+        // DecimalFormat silently ignores a '+' in the exponent, and everything
+        // that follows it. So parse the exponent ourselves and scale accordingly.
+        BigDecimal significand = toBigDecimal(parseSignificand(s.substring(0, index)));
+        return significand.scaleByPowerOfTen(parseExponent(s.substring(index + exponentSeparator.length())));
+    }
+
+    private Number parseSignificand(String s) {
+        // DecimalFormat has no positive prefix, so it can not parse a leading
+        // '+'. It does not change the value, so drop it.
+        String significand = s.startsWith("+") ? s.substring(1) : s;
         try {
-            return numberFormat.parse(removeExponentPlusSign(s));
+            return numberFormat.parse(significand);
         } catch (ParseException e) {
             throw new CucumberExpressionException("Failed to parse number", e);
         }
     }
 
-    private String removeExponentPlusSign(String s) {
-        String exponentPlus = exponentSeparator + "+";
-        int index = s.indexOf(exponentPlus);
-        if (index < 0) {
-            return s;
+    private static int parseExponent(String s) {
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            throw new CucumberExpressionException("Failed to parse number", e);
         }
-        return s.substring(0, index + exponentSeparator.length())
-                + s.substring(index + exponentPlus.length());
+    }
+
+    private static BigDecimal toBigDecimal(Number number) {
+        if (number instanceof BigDecimal bigDecimal) {
+            return bigDecimal;
+        }
+        // The locale did not have a DecimalFormat, so we could not
+        // ask it to parse into a BigDecimal.
+        return new BigDecimal(number.toString());
     }
 }

--- a/java/src/main/java/io/cucumber/cucumberexpressions/NumberParser.java
+++ b/java/src/main/java/io/cucumber/cucumberexpressions/NumberParser.java
@@ -37,7 +37,7 @@ final class NumberParser {
         }
         // Fall back to default big decimal format
         // if the locale does not have a DecimalFormat
-        return new BigDecimal(removeExponentPlusSign(s));
+        return new BigDecimal(s);
     }
 
     private Number parse(String s) {

--- a/java/src/main/java/io/cucumber/cucumberexpressions/NumberParser.java
+++ b/java/src/main/java/io/cucumber/cucumberexpressions/NumberParser.java
@@ -9,14 +9,18 @@ import java.util.Locale;
 
 final class NumberParser {
     private final NumberFormat numberFormat;
+    private final String exponentSeparator;
 
     NumberParser(Locale locale) {
         numberFormat = DecimalFormat.getNumberInstance(locale);
+        String exponentSeparator = "E";
         if (numberFormat instanceof DecimalFormat decimalFormat) {
             decimalFormat.setParseBigDecimal(true);
             DecimalFormatSymbols symbols = KeyboardFriendlyDecimalFormatSymbols.getInstance(locale);
             decimalFormat.setDecimalFormatSymbols(symbols);
+            exponentSeparator = symbols.getExponentSeparator();
         }
+        this.exponentSeparator = exponentSeparator;
     }
 
     double parseDouble(String s) {
@@ -33,14 +37,36 @@ final class NumberParser {
         }
         // Fall back to default big decimal format
         // if the locale does not have a DecimalFormat
-        return new BigDecimal(s);
+        return new BigDecimal(removeExponentPlusSign(s));
     }
 
     private Number parse(String s) {
         try {
-            return numberFormat.parse(s);
+            return numberFormat.parse(removeExponentPlusSign(s));
         } catch (ParseException e) {
             throw new CucumberExpressionException("Failed to parse number", e);
         }
+    }
+
+    /**
+     * Removes the {@code +} from a positive exponent, if present.
+     * <p>
+     * {@link DecimalFormat} stops parsing when it reaches an explicit {@code +}
+     * in the exponent and silently returns what it has read so far, so
+     * {@code 1.5E+3} parses as {@code 1.5} rather than failing. It handles the
+     * exponent correctly without the sign, and {@code E3} means the same as
+     * {@code E+3}, so dropping the sign is enough.
+     * <p>
+     * Doing it this way rather than delegating to {@link Double#valueOf} keeps
+     * parsing locale aware, and keeps {@code {bigdecimal}} exact.
+     */
+    private String removeExponentPlusSign(String s) {
+        String exponentPlus = exponentSeparator + "+";
+        int index = s.indexOf(exponentPlus);
+        if (index < 0) {
+            return s;
+        }
+        return s.substring(0, index + exponentSeparator.length())
+                + s.substring(index + exponentPlus.length());
     }
 }

--- a/java/src/main/java/io/cucumber/cucumberexpressions/NumberParser.java
+++ b/java/src/main/java/io/cucumber/cucumberexpressions/NumberParser.java
@@ -48,18 +48,6 @@ final class NumberParser {
         }
     }
 
-    /**
-     * Removes the {@code +} from a positive exponent, if present.
-     * <p>
-     * {@link DecimalFormat} stops parsing when it reaches an explicit {@code +}
-     * in the exponent and silently returns what it has read so far, so
-     * {@code 1.5E+3} parses as {@code 1.5} rather than failing. It handles the
-     * exponent correctly without the sign, and {@code E3} means the same as
-     * {@code E+3}, so dropping the sign is enough.
-     * <p>
-     * Doing it this way rather than delegating to {@link Double#valueOf} keeps
-     * parsing locale aware, and keeps {@code {bigdecimal}} exact.
-     */
     private String removeExponentPlusSign(String s) {
         String exponentPlus = exponentSeparator + "+";
         int index = s.indexOf(exponentPlus);

--- a/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
+++ b/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
@@ -29,7 +29,7 @@ public final class ParameterTypeRegistry {
     );
     private static final String SIGN = "[-+]?";
     private static final String MUST_CONTAIN_NUMBER = "(?=\\S*\\d\\S*)";
-    private static final String SCIENTIFIC_NUMBER = "(?:\\d+[{expnt}]-?\\d+)?";
+    private static final String SCIENTIFIC_NUMBER = "(?:\\d+[{expnt}][+-]?\\d+)?";
     private static final String DECIMAL_FRACTION = "(?:[{decimal}](?=\\d.*))?\\d*";
     private static final String INTEGER = "(?:\\d+(?:[{group}]?\\d+)*)*";
     private static final String FLOAT_REGEXPS =

--- a/java/src/test/java/io/cucumber/cucumberexpressions/NumberParserTest.java
+++ b/java/src/test/java/io/cucumber/cucumberexpressions/NumberParserTest.java
@@ -70,6 +70,32 @@ class NumberParserTest {
     }
 
     @Test
+    void can_parse_positive_exponents() {
+        assertEquals(new BigDecimal("100"), english.parseBigDecimal("1.00E+2"));
+        assertEquals(new BigDecimal("100"), german.parseBigDecimal("1,00E+2"));
+        assertEquals(new BigDecimal("100"), canadianFrench.parseBigDecimal("1,00E+2"));
+        assertEquals(new BigDecimal("100"), norwegian.parseBigDecimal("1,00E+2"));
+
+        assertEquals(1500.0, english.parseDouble("1.5E+3"), 0);
+        assertEquals(1500.0f, english.parseFloat("1.5E+3"), 0);
+    }
+
+    @Test
+    void can_parse_leading_plus_sign() {
+        assertEquals(new BigDecimal("1.5"), english.parseBigDecimal("+1.5"));
+        assertEquals(new BigDecimal("1.5"), german.parseBigDecimal("+1,5"));
+        assertEquals(new BigDecimal("1.5"), canadianFrench.parseBigDecimal("+1,5"));
+        assertEquals(new BigDecimal("1.5"), norwegian.parseBigDecimal("+1,5"));
+
+        assertEquals(1042.2f, english.parseFloat("+1,042.2"), 0);
+        assertEquals(1042.2f, german.parseFloat("+1.042,2"), 0);
+
+        // A leading plus sign combined with an exponent
+        assertEquals(new BigDecimal("1.5E+3"), english.parseBigDecimal("+1.5E+3"));
+        assertEquals(1500.0, english.parseDouble("+1.5E+3"), 0);
+    }
+
+    @Test
     @DisabledOnJre(versions = 17, disabledReason = "Locale information on JDK 17 uses lower case e for exponents")
     void can_parse_exponents_canadian() {
         assertEquals(new BigDecimal("100"), canadian.parseBigDecimal("1.00E2"));

--- a/java/src/test/java/io/cucumber/cucumberexpressions/ParameterTypeRegistryTest.java
+++ b/java/src/test/java/io/cucumber/cucumberexpressions/ParameterTypeRegistryTest.java
@@ -132,8 +132,9 @@ public class ParameterTypeRegistryTest {
         assertThat(expression.match("E1")).isEmpty();
         asserThatSingleArgumentValue(expression.match("-.1E-1")).isEqualTo(new BigDecimal("-0.01"));
         asserThatSingleArgumentValue(expression.match("-.1E-2")).isEqualTo(new BigDecimal("-0.001"));
-        assertThat(expression.match("-.1E+1")).isEmpty();
-        assertThat(expression.match("-.1E+2")).isEmpty();
+        asserThatSingleArgumentValue(expression.match("-.1E+1")).isEqualTo(new BigDecimal("-1"));
+        // precision 1 with scale -1, can not be expressed as a decimal
+        asserThatSingleArgumentValue(expression.match("-.1E+2")).isEqualTo(new BigDecimal("-1E+1"));
         asserThatSingleArgumentValue(expression.match("-.1E1")).isEqualTo(new BigDecimal("-1"));
         asserThatSingleArgumentValue(expression.match("-.10E2")).isEqualTo(new BigDecimal("-10"));
     }
@@ -147,6 +148,7 @@ public class ParameterTypeRegistryTest {
         asserThatSingleArgumentValue(expression.match("1.000.000,1")).isEqualTo(new BigDecimal("1000000.1"));
         asserThatSingleArgumentValue(expression.match("-1,1")).isEqualTo(new BigDecimal("-1.1"));
         asserThatSingleArgumentValue(expression.match("-,1E1")).isEqualTo(new BigDecimal("-1"));
+        asserThatSingleArgumentValue(expression.match("-,1E+1")).isEqualTo(new BigDecimal("-1"));
     }
 
     @Test

--- a/java/src/test/java/io/cucumber/cucumberexpressions/ParameterTypeRegistryTest.java
+++ b/java/src/test/java/io/cucumber/cucumberexpressions/ParameterTypeRegistryTest.java
@@ -133,7 +133,6 @@ public class ParameterTypeRegistryTest {
         asserThatSingleArgumentValue(expression.match("-.1E-1")).isEqualTo(new BigDecimal("-0.01"));
         asserThatSingleArgumentValue(expression.match("-.1E-2")).isEqualTo(new BigDecimal("-0.001"));
         asserThatSingleArgumentValue(expression.match("-.1E+1")).isEqualTo(new BigDecimal("-1"));
-        // precision 1 with scale -1, can not be expressed as a decimal
         asserThatSingleArgumentValue(expression.match("-.1E+2")).isEqualTo(new BigDecimal("-1E+1"));
         asserThatSingleArgumentValue(expression.match("-.1E1")).isEqualTo(new BigDecimal("-1"));
         asserThatSingleArgumentValue(expression.match("-.10E2")).isEqualTo(new BigDecimal("-10"));

--- a/java/src/test/java/io/cucumber/cucumberexpressions/ParameterTypeRegistryTest.java
+++ b/java/src/test/java/io/cucumber/cucumberexpressions/ParameterTypeRegistryTest.java
@@ -111,9 +111,11 @@ public class ParameterTypeRegistryTest {
         assertThat(expression.match("1,")).isEmpty();
         assertThat(expression.match(",1")).isEmpty();
         assertThat(expression.match("1.")).isEmpty();
+        assertThat(expression.match("+")).isEmpty();
 
         asserThatSingleArgumentValue(expression.match("1")).isEqualTo(BigDecimal.ONE);
         asserThatSingleArgumentValue(expression.match("-1")).isEqualTo(new BigDecimal("-1"));
+        asserThatSingleArgumentValue(expression.match("+1")).isEqualTo(BigDecimal.ONE);
         asserThatSingleArgumentValue(expression.match("1.1")).isEqualTo(new BigDecimal("1.1"));
         asserThatSingleArgumentValue(expression.match("1,000")).isEqualTo(new BigDecimal("1000"));
         asserThatSingleArgumentValue(expression.match("1,000,0")).isEqualTo(new BigDecimal("10000"));
@@ -136,6 +138,11 @@ public class ParameterTypeRegistryTest {
         asserThatSingleArgumentValue(expression.match("-.1E+2")).isEqualTo(new BigDecimal("-1E+1"));
         asserThatSingleArgumentValue(expression.match("-.1E1")).isEqualTo(new BigDecimal("-1"));
         asserThatSingleArgumentValue(expression.match("-.10E2")).isEqualTo(new BigDecimal("-10"));
+
+        asserThatSingleArgumentValue(expression.match("+1.1")).isEqualTo(new BigDecimal("1.1"));
+        asserThatSingleArgumentValue(expression.match("+1,000.1")).isEqualTo(new BigDecimal("1000.1"));
+        asserThatSingleArgumentValue(expression.match("+.1")).isEqualTo(new BigDecimal("0.1"));
+        asserThatSingleArgumentValue(expression.match("+.1E+2")).isEqualTo(new BigDecimal("1E+1"));
     }
 
     @Test
@@ -148,6 +155,8 @@ public class ParameterTypeRegistryTest {
         asserThatSingleArgumentValue(expression.match("-1,1")).isEqualTo(new BigDecimal("-1.1"));
         asserThatSingleArgumentValue(expression.match("-,1E1")).isEqualTo(new BigDecimal("-1"));
         asserThatSingleArgumentValue(expression.match("-,1E+1")).isEqualTo(new BigDecimal("-1"));
+        asserThatSingleArgumentValue(expression.match("+1.000,1")).isEqualTo(new BigDecimal("1000.1"));
+        asserThatSingleArgumentValue(expression.match("+,1E+1")).isEqualTo(BigDecimal.ONE);
     }
 
     @Test

--- a/javascript/src/defineDefaultParameterTypes.ts
+++ b/javascript/src/defineDefaultParameterTypes.ts
@@ -2,7 +2,7 @@ import ParameterType from './ParameterType.js'
 import type { DefinesParameterType } from './types.js'
 
 const INTEGER_REGEXPS = [/-?\d+/, /\d+/]
-const FLOAT_REGEXP = /(?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][+-]?\d+)?/
+const FLOAT_REGEXP = /[-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[E][+-]?\d+)?/
 const WORD_REGEXP = /[^\s]+/
 const STRING_REGEXP = /"([^"\\]*(\\.[^"\\]*)*)"|'([^'\\]*(\\.[^'\\]*)*)'/
 const ANONYMOUS_REGEXP = /.*/

--- a/python/src/cucumber_expressions/parameter_type_registry.py
+++ b/python/src/cucumber_expressions/parameter_type_registry.py
@@ -10,7 +10,7 @@ from cucumber_expressions.expression_generator import CucumberExpressionGenerato
 from cucumber_expressions.parameter_type import ParameterType
 
 INTEGER_REGEXPS = [re.compile(r"-?\d+"), re.compile(r"\d+")]
-FLOAT_REGEXP = re.compile(r"(?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][+-]?\d+)?")
+FLOAT_REGEXP = re.compile(r"[-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[E][+-]?\d+)?")
 WORD_REGEXP = re.compile(r"[^\s]+")
 STRING_REGEXPS = [
     re.compile(r'"([^\"\\]*(\\.[^\"\\]*)*)"'),

--- a/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
+++ b/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
@@ -9,7 +9,7 @@ module Cucumber
   module CucumberExpressions
     class ParameterTypeRegistry
       INTEGER_REGEXPS = [/-?\d+/, /\d+/].freeze
-      FLOAT_REGEXP = /(?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][-+]?\d+)?/.freeze
+      FLOAT_REGEXP = /[-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[E][+-]?\d+)?/.freeze
       WORD_REGEXP = /[^\s]+/.freeze
       STRING_REGEXP = /"([^"\\]*(\\.[^"\\]*)*)"|'([^'\\]*(\\.[^'\\]*)*)'/.freeze
       ANONYMOUS_REGEXP = /.*/.freeze

--- a/testdata/cucumber-expression/matching/matches-float-leading-plus-scientific-notation.yaml
+++ b/testdata/cucumber-expression/matching/matches-float-leading-plus-scientific-notation.yaml
@@ -1,0 +1,5 @@
+---
+expression: "{float}"
+text: '+1.5E+3'
+expected_args:
+- 1500.0

--- a/testdata/cucumber-expression/matching/matches-float-leading-plus.yaml
+++ b/testdata/cucumber-expression/matching/matches-float-leading-plus.yaml
@@ -1,0 +1,5 @@
+---
+expression: "{float}"
+text: '+3.141593'
+expected_args:
+- 3.141593

--- a/testdata/cucumber-expression/matching/matches-float-scientific-notation.yaml
+++ b/testdata/cucumber-expression/matching/matches-float-scientific-notation.yaml
@@ -1,0 +1,5 @@
+---
+expression: "{float}"
+text: '1.5E+3'
+expected_args:
+- 1500.0


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

Better support for scientific notation. Also fixes #399.

Go supports parsing of scientific notation floats, so I can't think of a good reason not to support it. It was explicitly disabled in 8999fb08, but I'm unsure of the motivation.

Java supports it too, if we remove the `+` before parsing.

And .NET supports it - no reason to gate it (although the actual conversion happens in ReqnRoll, not this library).

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

Don't be restrictive when there is no need for it.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)
- :boom: Breaking change (incompatible changes to the API)

I'm not 100% sure if this is breaking or not. The parser becomes more permissive, so I don't think it breaks anything, except perhaps in ReqnRoll if it's not able to turn scientific notation strings into floats.

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
