### PR TITLE
feat(dotnet): add a parameter type registry and argument conversion

### DIFF
--- a/dotnet/CucumberExpressions.Tests/CucumberExpressionGeneratorTest.cs
+++ b/dotnet/CucumberExpressions.Tests/CucumberExpressionGeneratorTest.cs
@@ -9,7 +9,7 @@ namespace CucumberExpressions.Tests;
 public class CucumberExpressionGeneratorTest : CucumberExpressionTestBase
 {
 
-    private readonly StubParameterTypeRegistry _parameterTypeRegistry = new();
+    private readonly ParameterTypeRegistry _parameterTypeRegistry = new();
     private readonly CucumberExpressionGenerator _generator;
 
     public CucumberExpressionGeneratorTest()

--- a/dotnet/CucumberExpressions.Tests/CucumberExpressionTest.cs
+++ b/dotnet/CucumberExpressions.Tests/CucumberExpressionTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Globalization;
 using System.Linq;
 using AwesomeAssertions;
 using Xunit;
@@ -10,7 +11,7 @@ namespace CucumberExpressions.Tests;
 
 public class CucumberExpressionTest : CucumberExpressionTestBase
 {
-    private readonly IParameterTypeRegistry _parameterTypeRegistry = new StubParameterTypeRegistry();
+    private readonly IParameterTypeRegistry _parameterTypeRegistry = new ParameterTypeRegistry();
     private readonly ITestOutputHelper _testOutputHelper;
 
     public CucumberExpressionTest(ITestOutputHelper testOutputHelper)
@@ -40,10 +41,7 @@ public class CucumberExpressionTest : CucumberExpressionTestBase
             _testOutputHelper.WriteLine(expression.Regex.ToString());
             var match = MatchExpression(expression, expectation.text);
 
-            var values = match == null ? null : match
-                .ToList();
-
-            Assert.Equal(expectation.expected_args, values);
+            AssertArgumentsMatch(expectation.expected_args, match);
         }
         else
         {
@@ -55,6 +53,28 @@ public class CucumberExpressionTest : CucumberExpressionTestBase
                 .Should().Throw<CucumberExpressionException>().WithMessage(expectation.exception);
         }
     }
+
+    private static void AssertArgumentsMatch(List<string> expected, object[] actual)
+    {
+        if (expected == null || actual == null)
+        {
+            Assert.True(expected == null && actual == null);
+            return;
+        }
+
+        Assert.Equal(expected.Count, actual.Length);
+        foreach (var (want, got) in expected.Zip(actual))
+            Assert.True(ValueMatches(want, got), $"expected {want ?? "null"}, got {got ?? "null"}");
+    }
+
+    private static bool ValueMatches(string expected, object actual)
+        => actual switch
+        {
+            null => expected == null,
+            float f => float.TryParse(expected, NumberStyles.Float, CultureInfo.InvariantCulture, out var e) && e == f,
+            double d => double.TryParse(expected, NumberStyles.Float, CultureInfo.InvariantCulture, out var e) && e == d,
+            _ => expected == Convert.ToString(actual, CultureInfo.InvariantCulture)
+        };
 
     public class Expectation
     {

--- a/dotnet/CucumberExpressions.Tests/CucumberExpressionTestBase.cs
+++ b/dotnet/CucumberExpressions.Tests/CucumberExpressionTestBase.cs
@@ -17,7 +17,6 @@ public abstract class CucumberExpressionTestBase : TestBase
 
         public StubParameterType(string name, params string[] regexps) : this(name, regexps, true)
         {
-
         }
 
         public StubParameterType(string name, string[] regexps, bool useForSnippets = true, int weight = 0)
@@ -29,65 +28,19 @@ public abstract class CucumberExpressionTestBase : TestBase
         }
     }
 
-    public class StubParameterTypeRegistry : IParameterTypeRegistry
+    public object[] MatchExpression(IExpression expression, string text)
     {
-        private readonly List<IParameterType> _parameterTypes = new()
+        if (expression is CucumberExpression cucumberExpression)
         {
-            new StubParameterType<int>(ParameterTypeConstants.IntParameterName, ParameterTypeConstants.IntParameterRegexps, weight: 1000),
-            new StubParameterType<string>(ParameterTypeConstants.StringParameterName, ParameterTypeConstants.StringParameterRegexps),
-            new StubParameterType<string>(ParameterTypeConstants.WordParameterName, ParameterTypeConstants.WordParameterRegexps, false),
-            new StubParameterType<float>(ParameterTypeConstants.FloatParameterName, ParameterTypeConstants.FloatParameterRegexpsEn, false),
-            new StubParameterType<double>(ParameterTypeConstants.DoubleParameterName, ParameterTypeConstants.FloatParameterRegexpsEn)
-        };
-
-        public IParameterType LookupByTypeName(string name)
-        {
-            if (name == "unknown")
-                return null;
-
-            var paramType = _parameterTypes.FirstOrDefault(pt => pt.Name == name);
-            if (paramType != null)
-                return paramType;
-
-            return new StubParameterType<string>("???", ".*");
+            var arguments = cucumberExpression.Match(text);
+            return arguments?.Select(argument => argument.GetValue()).ToArray();
         }
 
-        public IEnumerable<IParameterType> GetParameterTypes()
-        {
-            return _parameterTypes;
-        }
-
-        public void DefineParameterType(IParameterType parameterType)
-        {
-            _parameterTypes.Add(parameterType);
-        }
-
-        public void Remove(IParameterType parameterType)
-        {
-            _parameterTypes.Remove(parameterType);
-        }
-    }
-
-    private string TrimQuotes(string s)
-    {
-        if (s.Length >= 2 &&
-            ((s[0] == '"' && s[^1] == '"') ||
-             (s[0] == '\'' && s[^1] == '\'')))
-            return s.Substring(1, s.Length - 2).Replace(@"\" + s[0], s[0].ToString());
-        return s;
-    }
-
-    public string[] MatchExpression(IExpression expression, string text)
-    {
-        var match = expression.Regex.Match(text);
-        if (!match.Success)
+        var group = new Parsing.TreeRegexp(expression.Regex).Match(text);
+        if (group == null)
             return null;
-        return match.Groups.OfType<System.Text.RegularExpressions.Group>().Skip(1)
-            .Where(g => g.Success)
-            .Select(c => c.Value)
-            .Select(v => v.StartsWith(".") ? "0" + v : v) // simulate float parsing with leading dot (.123)
-            .Select(v => v.Replace(@"\""", @"""").Replace(@"\'", @"'")) // simulate quote masking
-            .Select(TrimQuotes)
-            .ToArray();
+
+        var argumentGroups = group.Children ?? new List<Parsing.Group>();
+        return argumentGroups.Select(g => (object)g.Value).ToArray();
     }
 }

--- a/dotnet/CucumberExpressions.Tests/CucumberExpressionTransformationTest.cs
+++ b/dotnet/CucumberExpressions.Tests/CucumberExpressionTransformationTest.cs
@@ -9,16 +9,12 @@ namespace CucumberExpressions.Tests;
 
 public class CucumberExpressionTransformationTest : CucumberExpressionTestBase
 {
-    private readonly StubParameterTypeRegistry _parameterTypeRegistry = new();
+    private readonly ParameterTypeRegistry _parameterTypeRegistry = new();
     private readonly ITestOutputHelper _testOutputHelper;
 
     public CucumberExpressionTransformationTest(ITestOutputHelper testOutputHelper)
     {
         _testOutputHelper = testOutputHelper;
-        var oldIntParameterType = _parameterTypeRegistry.LookupByTypeName("int");
-        _parameterTypeRegistry.Remove(oldIntParameterType);
-        _parameterTypeRegistry.DefineParameterType(new StubParameterType<int>(ParameterTypeConstants.IntParameterName, 
-            new []{ ParameterTypeConstants.IntParameterRegex, "\\d+" }, weight: 1000));
     }
 
     public static IEnumerable<object[]> acceptance_tests_pass_data()

--- a/dotnet/CucumberExpressions.Tests/ExpressionFactoryTest.cs
+++ b/dotnet/CucumberExpressions.Tests/ExpressionFactoryTest.cs
@@ -103,6 +103,6 @@ public class ExpressionFactoryTest : CucumberExpressionTestBase
 
     private IExpression CreateExpression(string expressionString)
     {
-        return new ExpressionFactory(new StubParameterTypeRegistry()).CreateExpression(expressionString);
+        return new ExpressionFactory(new ParameterTypeRegistry()).CreateExpression(expressionString);
     }
 }

--- a/dotnet/CucumberExpressions/Argument.cs
+++ b/dotnet/CucumberExpressions/Argument.cs
@@ -1,0 +1,23 @@
+using CucumberExpressions.Parsing;
+
+namespace CucumberExpressions;
+
+public class Argument
+{
+    public Group Group { get; }
+    public IParameterType ParameterType { get; }
+
+    public Argument(Group group, IParameterType parameterType)
+    {
+        Group = group;
+        ParameterType = parameterType;
+    }
+
+    public object GetValue()
+    {
+        var groupValues = Group?.GetValues();
+        if (ParameterType is IParameterTypeTransformer transformer)
+            return transformer.Transform(groupValues);
+        return groupValues == null ? null : groupValues[0];
+    }
+}

--- a/dotnet/CucumberExpressions/CucumberExpression.cs
+++ b/dotnet/CucumberExpressions/CucumberExpression.cs
@@ -19,6 +19,22 @@ public class CucumberExpression : IExpression
     public Regex Regex => _treeRegexp.Regex;
     public IParameterType[] ParameterTypes => _parameterTypes.ToArray();
 
+    public virtual Argument[] Match(string text)
+    {
+        var group = _treeRegexp.Match(text);
+        if (group == null)
+            return null;
+
+        var argumentGroups = group.Children ?? new List<Parsing.Group>();
+        if (argumentGroups.Count != _parameterTypes.Count)
+            throw new CucumberExpressionException(
+                $"Expression {Source} has {argumentGroups.Count} capture groups, but there were {_parameterTypes.Count} parameter types");
+
+        return argumentGroups
+            .Select((argumentGroup, i) => new Argument(argumentGroup, _parameterTypes[i]))
+            .ToArray();
+    }
+
     public CucumberExpression(string expression, IParameterTypeRegistry parameterTypeRegistry)
     {
         Source = expression;

--- a/dotnet/CucumberExpressions/IParameterTypeTransformer.cs
+++ b/dotnet/CucumberExpressions/IParameterTypeTransformer.cs
@@ -1,0 +1,6 @@
+namespace CucumberExpressions;
+
+public interface IParameterTypeTransformer
+{
+    object Transform(string[] groupValues);
+}

--- a/dotnet/CucumberExpressions/ParameterType.cs
+++ b/dotnet/CucumberExpressions/ParameterType.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace CucumberExpressions;
+
+public class ParameterType<T> : IParameterType, IParameterTypeTransformer
+{
+    private readonly Func<string[], T> _transformer;
+
+    public string Name { get; }
+    public string[] RegexStrings { get; }
+    public Type Type => typeof(T);
+
+    Type IParameterType.ParameterType => typeof(T);
+    public int Weight { get; }
+    public bool UseForSnippets { get; }
+
+    public ParameterType(
+        string name,
+        string[] regexStrings,
+        Func<string[], T> transformer,
+        bool useForSnippets = true,
+        int weight = 0)
+    {
+        if (regexStrings == null || regexStrings.Length == 0)
+            throw new ArgumentException("regexStrings must not be empty", nameof(regexStrings));
+
+        Name = name;
+        RegexStrings = regexStrings;
+        _transformer = transformer ?? throw new ArgumentNullException(nameof(transformer));
+        UseForSnippets = useForSnippets;
+        Weight = weight;
+    }
+
+    public ParameterType(
+        string name,
+        string regexString,
+        Func<string, T> transformer,
+        bool useForSnippets = true,
+        int weight = 0)
+        : this(name, new[] { regexString }, groupValues => transformer(groupValues[0]), useForSnippets, weight)
+    {
+    }
+
+    public object Transform(string[] groupValues) => _transformer(groupValues);
+}

--- a/dotnet/CucumberExpressions/ParameterTypeRegistry.cs
+++ b/dotnet/CucumberExpressions/ParameterTypeRegistry.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+
+namespace CucumberExpressions;
+
+public class ParameterTypeRegistry : IParameterTypeRegistry
+{
+    private readonly Dictionary<string, IParameterType> _parameterTypesByName = new();
+    private readonly List<IParameterType> _parameterTypes = new();
+    private readonly CultureInfo _cultureInfo;
+
+    public ParameterTypeRegistry()
+        : this(CultureInfo.InvariantCulture)
+    {
+    }
+
+    public ParameterTypeRegistry(CultureInfo cultureInfo)
+    {
+        _cultureInfo = cultureInfo ?? throw new ArgumentNullException(nameof(cultureInfo));
+        foreach (var parameterType in CreateDefaultParameterTypes())
+            DefineParameterType(parameterType);
+    }
+
+    public IParameterType LookupByTypeName(string name)
+        => _parameterTypesByName.TryGetValue(name, out var parameterType) ? parameterType : null;
+
+    public IEnumerable<IParameterType> GetParameterTypes() => _parameterTypes;
+
+    public void DefineParameterType(IParameterType parameterType)
+    {
+        if (parameterType == null) throw new ArgumentNullException(nameof(parameterType));
+
+        if (parameterType.Name != null)
+        {
+            if (_parameterTypesByName.ContainsKey(parameterType.Name))
+                throw new CucumberExpressionException(parameterType.Name.Length == 0
+                    ? "The anonymous parameter type has already been defined"
+                    : $"There is already a parameter type with name {parameterType.Name}");
+
+            _parameterTypesByName.Add(parameterType.Name, parameterType);
+        }
+
+        _parameterTypes.Add(parameterType);
+    }
+
+    private IEnumerable<IParameterType> CreateDefaultParameterTypes()
+    {
+        var floatRegexps = new[] { ParameterTypeConstants.GetFloatParameterRegex(_cultureInfo) };
+        var integerRegexps = new[] { ParameterTypeConstants.IntParameterRegex, "\\d+" };
+
+        yield return new ParameterType<int>(
+            ParameterTypeConstants.IntParameterName,
+            integerRegexps,
+            groupValues => int.Parse(groupValues[0], NumberStyles.Integer, _cultureInfo),
+            true, 1000);
+
+        yield return new ParameterType<float>(
+            ParameterTypeConstants.FloatParameterName,
+            floatRegexps,
+            groupValues => float.Parse(RemoveExponentPlusSign(groupValues[0]), NumberStyles.Float | NumberStyles.AllowThousands, _cultureInfo),
+            false);
+
+        yield return new ParameterType<string>(
+            ParameterTypeConstants.WordParameterName,
+            ParameterTypeConstants.WordParameterRegexps,
+            groupValues => groupValues[0],
+            false);
+
+        yield return new ParameterType<string>(
+            ParameterTypeConstants.StringParameterName,
+            ParameterTypeConstants.StringParameterRegexps,
+            groupValues => UnescapeQuotes(groupValues[0]));
+
+        yield return new ParameterType<string>(
+            "",
+            new[] { ParameterTypeConstants.AnonymousParameterRegex },
+            groupValues => groupValues[0],
+            false);
+
+        yield return new ParameterType<double>(
+            ParameterTypeConstants.DoubleParameterName,
+            floatRegexps,
+            groupValues => double.Parse(RemoveExponentPlusSign(groupValues[0]), NumberStyles.Float | NumberStyles.AllowThousands, _cultureInfo));
+
+        yield return new ParameterType<string>(
+            "bigdecimal",
+            floatRegexps,
+            groupValues => groupValues[0],
+            false);
+
+        yield return new ParameterType<byte>(
+            "byte",
+            integerRegexps,
+            groupValues => byte.Parse(groupValues[0], NumberStyles.Integer, _cultureInfo),
+            false);
+
+        yield return new ParameterType<short>(
+            "short",
+            integerRegexps,
+            groupValues => short.Parse(groupValues[0], NumberStyles.Integer, _cultureInfo),
+            false);
+
+        yield return new ParameterType<long>(
+            "long",
+            integerRegexps,
+            groupValues => long.Parse(groupValues[0], NumberStyles.Integer, _cultureInfo),
+            false);
+
+        yield return new ParameterType<BigInteger>(
+            "biginteger",
+            integerRegexps,
+            groupValues => BigInteger.Parse(groupValues[0], NumberStyles.Integer, _cultureInfo),
+            false);
+    }
+
+    private string RemoveExponentPlusSign(string value)
+    {
+        var index = value.IndexOf("E+", StringComparison.Ordinal);
+        return index < 0 ? value : value.Substring(0, index + 1) + value.Substring(index + 2);
+    }
+
+    private static string UnescapeQuotes(string value)
+    {
+        if (value.Length < 2)
+            return value;
+
+        var quote = value[0];
+        if ((quote != '"' && quote != '\'') || value[value.Length - 1] != quote)
+            return value;
+
+        return value.Substring(1, value.Length - 2).Replace("\\" + quote, quote.ToString());
+    }
+}


### PR DESCRIPTION

<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

A full .NET implementation of `IParameterTypeRegistry` and `IParameterType`, aligned with the other implementations. 
### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

Three things.

First, testing the implementation against the `testdata` corpus with more fidelity. This was done with a simplistic `StubParameterTypeRegistry` that was only used in tests. With #441 it became apparent that it had to be changed to make the new `testdata` tests pass. 

Second, ReqnRoll isn't the only .NET consumer of Cucumber Expressions anymore - there is also Varar. Having Cucumber Expressions implemented consistently makes it a lot easier to maintain.

Third - the inconsistency adds cognitive overhead for the maintenance of this library.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

This should be entirely additive. No deletions, and no existing interface, member or constant is touched. Reqnroll keeps its own `IParameterTypeRegistry` and its own conversion.

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
