### PR TITLE
Use more efficient regex without lookahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Use more efficient regex without lookahead ([#443](https://github.com/cucumber/cucumber-expressions/pull/443))
+- [Go] Parse floating point numbers with scientific notation ([#443](https://github.com/cucumber/cucumber-expressions/pull/443))
+
 ## [20.0.0] - 2026-06-11
 ### Changed
 - [JavaScript] BREAKING CHANGE: Switch to ESM ([#431](https://github.com/cucumber/cucumber-expressions/pull/431))

--- a/dotnet/CucumberExpressions/ParameterTypeConstants.cs
+++ b/dotnet/CucumberExpressions/ParameterTypeConstants.cs
@@ -16,12 +16,13 @@ public static class ParameterTypeConstants
 
     public const string FloatParameterName = "float";
     public const string DoubleParameterName = "double";
-    private const string FloatPartSign = "[-+]?";
-    private const string FloatPartMustContainNumber = "(?=.*\\d.*)";
-    private const string FloatPartScientificNumber = "(?:\\d+[{exponent}]-?\\d+)?";
-    private const string FloatPartDecimalFraction = "(?:[{decimal}](?=\\d.*))?\\d*";
-    private const string FloatPartInteger = "(?:\\d+(?:[{group}]?\\d+)*)*";
-    public const string FloatParameterRegexTemplate = FloatPartMustContainNumber + FloatPartSign + FloatPartInteger + FloatPartDecimalFraction + FloatPartScientificNumber;
+    public const string FloatParameterRegexTemplate =
+        // Sign
+        "[-+]?" +
+        // Significant
+        "(?:\\d+(?:[{group}]\\d+)*(?:[{decimal}]\\d+)?|[{decimal}]\\d+)" +
+        // Exponent
+        "(?:[{exponent}][-]?\\d+)?";
     public static readonly string FloatParameterRegex = GetGenericFloatParameterRegex();
     public static readonly string[] FloatParameterRegexps = { FloatParameterRegex };
     public static readonly string FloatParameterRegexEn = GetFloatParameterRegex(CultureInfo.InvariantCulture);

--- a/go/cucumber_expression_test.go
+++ b/go/cucumber_expression_test.go
@@ -2,14 +2,15 @@ package cucumberexpressions
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"math/big"
 	"reflect"
 	"regexp"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 type CucumberExpressionMatchingExpectation struct {
@@ -106,14 +107,14 @@ func TestCucumberExpression(t *testing.T) {
 		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1"), []interface{}{-0.1})
 		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.10000001"), []interface{}{-0.10000001})
 		require.Equal(t, MatchCucumberExpression(t, "{float}", "1e1"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", ".1E1"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", ".1E1"), []interface{}{1.0})
 		require.Equal(t, MatchCucumberExpression(t, "{float}", "E1"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E-1"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E-2"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E+1"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E+2"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E1"), []interface{}(nil))
-		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.10E2"), []interface{}(nil))
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E-1"), []interface{}{-0.01})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E-2"), []interface{}{-0.001})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E+1"), []interface{}{-1.0})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E+2"), []interface{}{-10.0})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.1E1"), []interface{}{-1.0})
+		require.Equal(t, MatchCucumberExpression(t, "{float}", "-.10E2"), []interface{}{-10.0})
 	})
 
 	t.Run("matches float with zero", func(t *testing.T) {

--- a/go/custom_parameter_type_test.go
+++ b/go/custom_parameter_type_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 /// [color-constructor]
+
 type Color struct {
 	name string
 }

--- a/go/errors.go
+++ b/go/errors.go
@@ -109,7 +109,7 @@ func createInvalidParameterTypeName(typeName string) error {
 	return NewCucumberExpressionError("Illegal character in parameter name {" + typeName + "}. Parameter names may not contain '{', '}', '(', ')', '\\' or '/'")
 }
 
-//  Not very clear, but this message has to be language independent
+// Not very clear, but this message has to be language independent
 func createInvalidParameterTypeNameInNode(token token, expression string) error {
 	return NewCucumberExpressionError(message(
 		token.Start,

--- a/go/parameter_type_registry.go
+++ b/go/parameter_type_registry.go
@@ -13,7 +13,7 @@ var INTEGER_REGEXPS = []*regexp.Regexp{
 	regexp.MustCompile(`\d+`),
 }
 var FLOAT_REGEXPS = []*regexp.Regexp{
-	regexp.MustCompile(`[-+]?\d*\.?\d+`),
+	regexp.MustCompile(`[-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[E][+-]?\d+)?`),
 }
 var WORD_REGEXPS = []*regexp.Regexp{
 	regexp.MustCompile(`[^\s]+`),

--- a/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
+++ b/java/src/main/java/io/cucumber/cucumberexpressions/ParameterTypeRegistry.java
@@ -27,13 +27,15 @@ public final class ParameterTypeRegistry {
             Pattern.compile("-?\\d+").pattern(),
             Pattern.compile("\\d+").pattern()
     );
-    private static final String SIGN = "[-+]?";
-    private static final String MUST_CONTAIN_NUMBER = "(?=\\S*\\d\\S*)";
-    private static final String SCIENTIFIC_NUMBER = "(?:\\d+[{expnt}]-?\\d+)?";
-    private static final String DECIMAL_FRACTION = "(?:[{decimal}](?=\\d.*))?\\d*";
-    private static final String INTEGER = "(?:\\d+(?:[{group}]?\\d+)*)*";
     private static final String FLOAT_REGEXPS =
-            Pattern.compile(MUST_CONTAIN_NUMBER + SIGN + INTEGER + DECIMAL_FRACTION + SCIENTIFIC_NUMBER).pattern();
+            Pattern.compile(
+                    // Sign
+                    "[-+]?" +
+                    // Significant
+                    "(?:\\d+(?:[{group}]\\d+)*(?:[{decimal}]\\d+)?|[{decimal}]\\d+)" +
+                    // Exponent
+                    "(?:[{exponent}][-]?\\d+)?")
+                    .pattern();
     private static final List<String> WORD_REGEXPS = singletonList(
             Pattern.compile("[^\\s]+").pattern()
     );
@@ -64,7 +66,7 @@ public final class ParameterTypeRegistry {
         List<String> localizedFloatRegexp = singletonList(FLOAT_REGEXPS
                 .replace("{decimal}", "" + numberFormat.getDecimalSeparator())
                 .replace("{group}", "" + numberFormat.getGroupingSeparator())
-                .replace("{expnt}", "" + numberFormat.getExponentSeparator())
+                .replace("{exponent}", "" + numberFormat.getExponentSeparator())
         );
 
         defineParameterType(new ParameterType<>("biginteger", INTEGER_REGEXPS, BigInteger.class, new Transformer<>() {

--- a/javascript/src/defineDefaultParameterTypes.ts
+++ b/javascript/src/defineDefaultParameterTypes.ts
@@ -2,7 +2,7 @@ import ParameterType from './ParameterType.js'
 import type { DefinesParameterType } from './types.js'
 
 const INTEGER_REGEXPS = [/-?\d+/, /\d+/]
-const FLOAT_REGEXP = /(?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][+-]?\d+)?/
+const FLOAT_REGEXP = /[-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[E][+-]?\d+)?/
 const WORD_REGEXP = /[^\s]+/
 const STRING_REGEXP = /"([^"\\]*(\\.[^"\\]*)*)"|'([^'\\]*(\\.[^'\\]*)*)'/
 const ANONYMOUS_REGEXP = /.*/

--- a/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
+++ b/ruby/lib/cucumber/cucumber_expressions/parameter_type_registry.rb
@@ -9,7 +9,7 @@ module Cucumber
   module CucumberExpressions
     class ParameterTypeRegistry
       INTEGER_REGEXPS = [/-?\d+/, /\d+/].freeze
-      FLOAT_REGEXP = /(?=.*\d.*)[-+]?\d*(?:\.(?=\d.*))?\d*(?:\d+[E][-+]?\d+)?/.freeze
+      FLOAT_REGEXP = /[-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[E][+-]?\d+)?/.freeze
       WORD_REGEXP = /[^\s]+/.freeze
       STRING_REGEXP = /"([^"\\]*(\\.[^"\\]*)*)"|'([^'\\]*(\\.[^'\\]*)*)'/.freeze
       ANONYMOUS_REGEXP = /.*/.freeze


### PR DESCRIPTION
### 🤔 What's changed?

Use a regex without look ahead and for Go support floating point numbers with scientific notation.

### ⚡️ What's your motivation? 

Fixes: #399

### 🏷️ What kind of change is this?
- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
