### PR TITLE
Add a README to the .NET NuGet package #312

### DIFF
--- a/dotnet/CucumberExpressions/CucumberExpressions.csproj
+++ b/dotnet/CucumberExpressions/CucumberExpressions.csproj
@@ -26,6 +26,7 @@
 		<RepositoryType>git</RepositoryType>
 		<PackageIcon>cucumber-mark-green-128.png</PackageIcon>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageOutputPath>bin/$(Configuration)/NuGet</PackageOutputPath>
@@ -37,6 +38,7 @@
 			<PackagePath>.</PackagePath>
 			<Visible>true</Visible>
 		</None>
+		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 </Project>

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,0 +1,3 @@
+# Cucumber Expressions for .NET
+
+[The main docs are here](https://github.com/cucumber/cucumber-expressions#readme).


### PR DESCRIPTION
NuGet was warning that Cucumber.CucumberExpressions is missing a readme.

I added a short README like the Python one and packed it with PackageReadmeFile so the nupkg includes it.

Fixes #312