### PR TITLE
Document Python usage in the package README #311

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,3 +1,44 @@
 # Cucumber Expressions for Python
 
-[The main docs are here](https://github.com/cucumber/cucumber-expressions#readme).
+[Syntax, parameter types, and the playground](https://github.com/cucumber/cucumber-expressions#readme) are in the main docs. This page covers using the Python package.
+
+## Install
+
+```bash
+pip install cucumber-expressions
+```
+
+## Match text and read captured values
+
+```python
+from cucumber_expressions.expression import CucumberExpression
+from cucumber_expressions.parameter_type_registry import ParameterTypeRegistry
+
+expression = CucumberExpression("I have {int} cuke(s)", ParameterTypeRegistry())
+matches = expression.match("I have 7 cukes")
+count = matches[0].value  # 7
+```
+
+`match` returns `None` when the text does not match.
+
+Built-in parameter types include `{int}`, `{float}`, `{word}`, `{string}`, and `{}` (anonymous).
+
+## Custom parameter types
+
+```python
+from cucumber_expressions.expression import CucumberExpression
+from cucumber_expressions.parameter_type import ParameterType
+from cucumber_expressions.parameter_type_registry import ParameterTypeRegistry
+
+class Color:
+    def __init__(self, name: str):
+        self.name = name
+
+registry = ParameterTypeRegistry()
+registry.define_parameter_type(
+    ParameterType("color", r"red|blue|yellow", Color, lambda s: Color(s), True, False),
+)
+
+expression = CucumberExpression("I have a {color} ball", registry)
+color = expression.match("I have a red ball")[0].value
+```


### PR DESCRIPTION
### 🤔 What's changed?

Python package README now has install plus `match` / custom parameter type examples. PyPI was only showing a link to the main docs.

### ⚡️ What's your motivation?

Fixes #311

### 🏷️ What kind of change is this?

- Documentation (improvements without changing code)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] Documentation only; no code behaviour change