### PR TITLE
ruby: change default use_for_snippets to `false`

### DIFF
--- a/ruby/lib/cucumber/cucumber_expressions/parameter_type.rb
+++ b/ruby/lib/cucumber/cucumber_expressions/parameter_type.rb
@@ -11,32 +11,30 @@ module Cucumber
       attr_reader :name, :type, :transformer, :use_for_snippets, :prefer_for_regexp_match, :regexps
 
       def self.check_parameter_type_name(type_name)
-        raise CucumberExpressionError.new("Illegal character in parameter name {#{type_name}}. Parameter names may not contain '[]()$.|?*+'") unless is_valid_parameter_type_name(type_name)
+        raise CucumberExpressionError.new("Illegal character in parameter name {#{type_name}}. Parameter names may not contain '[]()$.|?*+'") unless valid_parameter_type_name?(type_name)
       end
 
-      def self.is_valid_parameter_type_name(type_name)
+      def self.valid_parameter_type_name?(type_name)
         unescaped_type_name = type_name.gsub(UNESCAPE_PATTERN) { Regexp.last_match(2) }
-        !(ILLEGAL_PARAMETER_NAME_PATTERN =~ unescaped_type_name)
+        !(ILLEGAL_PARAMETER_NAME_PATTERN.match?(unescaped_type_name))
       end
 
-      # Create a new Parameter
+      # Create a new ParameterType
       #
-      # @param name the name of the parameter type
-      # @param regexp [Array] list of regexps for capture groups. A single regexp can also be used
-      # @param type the return type of the transformed
-      # @param transformer lambda that transforms a String to (possibly) another type
-      # @param use_for_snippets true if this should be used for snippet generation
-      # @param prefer_for_regexp_match true if this should be preferred over similar types
+      # @param name [String] the name of the parameter type
+      # @param regexp [Array, Regexp] list of regexps for capture groups. A single regexp can also be used
+      # @param type [Object] the return type of the transformed
+      # @param transformer [Proc] lambda that transforms a String to (possibly) another type
+      # @param use_for_snippets [Boolean] true if this should be used for snippet generation
+      # @param prefer_for_regexp_match [Boolean] true if this should be preferred over similar types
       #
-      def initialize(name, regexp, type, transformer, use_for_snippets, prefer_for_regexp_match)
-        raise "regexp can't be nil" if regexp.nil?
-        raise "type can't be nil" if type.nil?
-        raise "transformer can't be nil" if transformer.nil?
-        raise "use_for_snippets can't be nil" if use_for_snippets.nil?
-        raise "prefer_for_regexp_match can't be nil" if prefer_for_regexp_match.nil?
-
+      def initialize(name, regexp, type, transformer, use_for_snippets = false, prefer_for_regexp_match = false)
         self.class.check_parameter_type_name(name) unless name.nil?
-        @name, @type, @transformer, @use_for_snippets, @prefer_for_regexp_match = name, type, transformer, use_for_snippets, prefer_for_regexp_match
+        @name = name
+        @type = type
+        @transformer = transformer
+        @use_for_snippets = use_for_snippets
+        @prefer_for_regexp_match = prefer_for_regexp_match
         @regexps = string_array(regexp)
       end
 
@@ -48,7 +46,7 @@ module Cucumber
         return -1 if prefer_for_regexp_match && !other.prefer_for_regexp_match
         return 1 if other.prefer_for_regexp_match && !prefer_for_regexp_match
 
-        return name <=> other.name
+        name <=> other.name
       end
 
       private


### PR DESCRIPTION
### 🤔 What's changed?

Make changes to fix consensus driven debate amongst contributors

### ⚡️ What's your motivation? 

After 9-10 years we should probably remove this default.
If the consensus is accepted then I can make a change for all other languages

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :boom: Breaking change (incompatible changes to the API)

### ♻️ Anything particular you want feedback on?

Requires consensus and changes to `website` repo.

Following this PR, there should be changes made to every flavour of cucumber if they have any local overrides to the Param type DSL creation

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
